### PR TITLE
Don't use xargs to generate the node name list 

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
@@ -44,7 +44,7 @@ end
 
 bash 'Add nodes to slurm config' do
   code <<-EOH
-    iplist=$(grep ip- /etc/hosts | awk '{print $2}' | cut -d'.' -f1 | xargs | sed 's/ /,/g')
+    iplist=$(grep ip- /etc/hosts | awk '{print $2}' | cut -d'.' -f1 | paste -sd "," -)
     echo "\nNodename=${iplist} State=FUTURE" >> /sched/slurm.conf
     touch /etc/slurm.installed
     EOH


### PR DESCRIPTION
xargs has a maximum length and will cause issues if the /etc/hosts file is very long (for example a /18 subnet). Use `paste` instead which doesn't seem to have this issue