### PR TITLE
Update Slurm project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 x64/
 x86/
 bld/
+build/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
@@ -328,3 +329,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# rpmbuild output
+*.rpm

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Slurm
 
 This project sets up an auto-scaling Slurm cluster
 
-   
+
 Pre-Requisites
 --------------
 
@@ -24,10 +24,12 @@ This sample requires the following:
 
   5. You must have access to a configured CycleCloud "Locker" for Project Storage
      (Cluster-Init and Chef).
-     
-  6. You need to either build the Slurm RPMs and put them in the `blobs/` directory 
-     or get them from someone who has already built them. There is a script in the 
-     cluster-init `scratch` directory to build the RPMs.
+
+  6. You need to build the Slurm RPMs and put them in the `blobs/` directory.
+     There is a script in the cluster-init `scratch` directory to build the RPMs on a cloud node.
+     Alternatively, you can run the included `./docker-rpmbuild.sh` on a development machine with
+     `docker` installed.  This `docker-rpmbuild.sh` script will generate the rpm files for
+     CentOS 7.x compatible nodes and place them in the `blobs/` directory.
 
   7. Optional: To use the `cyclecloud project upload <locker>` command, you must
      have a Pogo configuration file set up with write-access to your locker.
@@ -43,7 +45,7 @@ This sample requires the following:
 Usage
 =====
 
-A. Configuring the Project
+A. Deploying the Project
 --------------------------
 
 The first step is to configure the project for use with your storage locker:
@@ -52,23 +54,7 @@ The first step is to configure the project for use with your storage locker:
 
   2. Switch to the Slurm sample directory.
 
-  3. Run ``cyclecloud project add_target my_locker`` (assuming the locker is named "my_locker").
-     The locker name will generally be the same as the cloud provider you created when configuring
-     CycleCloud. The expected output looks like this:::
-
-       $ cyclecloud project add_target my_locker
-       Name: slurm
-       Version: 1.0.0
-       Targets:
-          my_locker: {'default': 'true', 'is_locker': 'true'}
-
-     NOTE: You may call add_target as many times as needed to add additional target lockers.
-
-       
-B. Deploying the Project
-------------------------
-
-To upload the project (including any local changes) to your target locker, run the
+  3. Upload the project (including any local changes) to your target locker, run the
 `cyclecloud project upload` command from the project directory.  The expected output looks like
 this:::
 
@@ -80,7 +66,7 @@ this:::
 For the upload to succeed, you must have a valid Pogo configuration for your target Locker.
 
 
-C. Importing the Cluster Template
+B. Importing the Cluster Template
 ---------------------------------
 
 To import the cluster:

--- a/docker-rpmbuild.sh
+++ b/docker-rpmbuild.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if command -v docker; then
+  docker run -v $(pwd)/specs/default/cluster-init/files:/source -v $(pwd)/blobs:/root/rpmbuild/RPMS/x86_64 -ti centos:7 /bin/bash /source/00-build-slurm.sh
+else
+  echo "`docker` binary not found. Install docker to build RPMs with this script"
+fi

--- a/project.ini
+++ b/project.ini
@@ -1,11 +1,11 @@
 [project]
 name = slurm
 label = Slurm
-version = 1.0.1
+version = 1.0.2
 type = scheduler
 
 [blobs]
-Files = slurm-17.11.7-1.el7.centos.x86_64.rpm, slurm-contribs-17.11.7-1.el7.centos.x86_64.rpm, slurm-devel-17.11.7-1.el7.centos.x86_64.rpm, slurm-example-configs-17.11.7-1.el7.centos.x86_64.rpm, slurm-openlava-17.11.7-1.el7.centos.x86_64.rpm, slurm-pam_slurm-17.11.7-1.el7.centos.x86_64.rpm, slurm-perlapi-17.11.7-1.el7.centos.x86_64.rpm, slurm-slurmctld-17.11.7-1.el7.centos.x86_64.rpm, slurm-slurmd-17.11.7-1.el7.centos.x86_64.rpm, slurm-slurmdbd-17.11.7-1.el7.centos.x86_64.rpm, slurm-torque-17.11.7-1.el7.centos.x86_64.rpm
+Files = slurm-17.11.12-1.el7.centos.x86_64.rpm, slurm-contribs-17.11.12-1.el7.centos.x86_64.rpm, slurm-devel-17.11.12-1.el7.centos.x86_64.rpm, slurm-example-configs-17.11.12-1.el7.centos.x86_64.rpm, slurm-openlava-17.11.12-1.el7.centos.x86_64.rpm, slurm-pam_slurm-17.11.12-1.el7.centos.x86_64.rpm, slurm-perlapi-17.11.12-1.el7.centos.x86_64.rpm, slurm-slurmctld-17.11.12-1.el7.centos.x86_64.rpm, slurm-slurmd-17.11.12-1.el7.centos.x86_64.rpm, slurm-slurmdbd-17.11.12-1.el7.centos.x86_64.rpm, slurm-torque-17.11.12-1.el7.centos.x86_64.rpm
 
 [spec master]
 run_list = role[slurm_master_role]
@@ -17,4 +17,4 @@ run_list = role[slurm_execute_role]
 Required = True
 Label = Slurm Version
 Description = Version of Slurm to install on the cluster
-DefaultValue = 17.11.7-1
+DefaultValue = 17.11.12-1

--- a/specs/default/chef/site-cookbooks/slurm/recipes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/default.rb
@@ -23,7 +23,6 @@ when 'ubuntu'
     to '/etc/slurm-llnl'
     owner "#{slurmuser}"
     group "#{slurmuser}"
-    mode '0700'
   end
 
   link '/bin/sinfo' do

--- a/specs/default/chef/site-cookbooks/slurm/recipes/execute.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/execute.rb
@@ -20,7 +20,6 @@ link '/etc/slurm/slurm.conf' do
   to '/sched/slurm.conf'
   owner "#{slurmuser}"
   group "#{slurmuser}"
-  mode '0700'
 end
 
 defer_block "Defer starting slurmd until end of converge" do

--- a/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
@@ -55,7 +55,6 @@ link '/etc/slurm/slurm.conf' do
   to '/sched/slurm.conf'
   owner "#{slurmuser}"
   group "#{slurmuser}"
-  mode '0700'
 end
 
 cookbook_file "/etc/security/limits.d/slurm-limits.conf" do

--- a/specs/default/cluster-init/files/00-build-slurm.sh
+++ b/specs/default/cluster-init/files/00-build-slurm.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-SLURM_PKG="slurm-17.11.5.tar.bz2"
+SLURM_VERSION="17.11.12"
+SLURM_PKG="slurm-${SLURM_VERSION}.tar.bz2"
 DOWNLOAD_URL="https://download.schedmd.com/slurm"
 
-yum install -y rpm-build munge-devel munge-libs readline-devel openssl-devel pam-devel perl-ExtUtils-MakeMaker gcc mysql mysql-devel
+# munge is in EPEL
+yum -y install epel-release && yum -q makecache
+
+# Install other build deps
+yum install -y rpm-build munge-devel munge-libs readline-devel openssl openssl-devel pam-devel perl-ExtUtils-MakeMaker gcc mysql mysql-devel wget
 wget "${DOWNLOAD_URL}/${SLURM_PKG}"
 
 rpmbuild -ta ${SLURM_PKG}

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -20,7 +20,7 @@ Autoscale = $Autoscale
         [[[configuration]]]
         slurm.version = $configuration_slurm_version
 
-        [[[cluster-init cyclecloud/slurm:default:1.0.1]]]
+        [[[cluster-init cyclecloud/slurm:default:1.0.2]]]
         Optional = true
 
     [[node master]]
@@ -30,7 +30,7 @@ Autoscale = $Autoscale
     
         [[[configuration]]]
 
-        [[[cluster-init cyclecloud/slurm:master:1.0.1]]]
+        [[[cluster-init cyclecloud/slurm:master:1.0.2]]]
 
         [[[network-interface eth0]]]
         AssociatePublicIpAddress = $UsePublicNetwork
@@ -50,7 +50,7 @@ Autoscale = $Autoscale
 
         [[[configuration]]]
 
-        [[[cluster-init cyclecloud/slurm:execute:1.0.1]]]
+        [[[cluster-init cyclecloud/slurm:execute:1.0.2]]]
 
         [[[network-interface eth0]]]
         AssociatePublicIpAddress = $ExecuteNodesPublic
@@ -145,7 +145,7 @@ Order = 20
 required = True
 label = Slurm Version
 description = Version of Slurm to install on the cluster
-defaultvalue = 17.11.7-1
+defaultvalue = 17.11.12-1
 
 
     [[parameters Software]]


### PR DESCRIPTION
* Remove file modes from symlinks, to knock out the `File.lchmod` calls
  which are failing.
* Remove deprecated `add_target` instructions.
* Add docker-rpmbuild.sh helper script, and documentation
* Add missing build time dependencies to build helper script
* Bump version to 1.0.2