### PR TITLE
Set UID/GID for slurm and munge users explicitly 

### DIFF
--- a/project.ini
+++ b/project.ini
@@ -1,7 +1,7 @@
 [project]
 name = slurm
 label = Slurm
-version = 1.0.2
+version = 1.0.3
 type = scheduler
 
 [blobs]

--- a/project.ini
+++ b/project.ini
@@ -1,7 +1,7 @@
 [project]
 name = slurm
 label = Slurm
-version = 1.0.3
+version = 1.1.0
 type = scheduler
 
 [blobs]
@@ -18,3 +18,45 @@ Required = True
 Label = Slurm Version
 Description = Version of Slurm to install on the cluster
 DefaultValue = 17.11.12-1
+
+
+[config slurm.user.name]
+Required = True
+Label = Slurm Username
+Description = Username for the slurm service account
+DefaultValue = slurm
+
+[config slurm.user.uid]
+Required = True
+Label = Slurm User ID
+Description = User ID for the slurm service account
+DefaultValue = 11100
+
+[config slurm.user.gid]
+Required = True
+Label = Slurm Group ID
+Description = Default Group ID for the slurm service account
+DefaultValue = 11100
+
+
+
+[config munge.user.name]
+Required = True
+Label = Munge Username
+Description = Username for the munge service account
+DefaultValue = munge
+
+[config munge.user.uid]
+Required = True
+Label = Munge User ID
+Description = User ID for the munge service account
+DefaultValue = 11101
+
+[config munge.user.gid]
+Required = True
+Label = Munge Group ID
+Description = Default Group ID for the munge service account
+DefaultValue = 11101
+
+
+

--- a/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
@@ -3,3 +3,8 @@
 default[:slurm][:version] = "17.11.7-1"
 default[:slurm][:arch] = "el7.centos.x86_64"
 default[:slurm][:user][:name] = 'slurm'
+default[:slurm][:user][:uid] = 19000
+default[:slurm][:user][:gid] = 19000
+default[:munge][:user][:name] = 'munge'
+default[:munge][:user][:uid] = 19001
+default[:munge][:user][:gid] = 19001

--- a/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
@@ -3,8 +3,8 @@
 default[:slurm][:version] = "17.11.7-1"
 default[:slurm][:arch] = "el7.centos.x86_64"
 default[:slurm][:user][:name] = 'slurm'
-default[:slurm][:user][:uid] = 19000
-default[:slurm][:user][:gid] = 19000
+default[:slurm][:user][:uid] = 11100
+default[:slurm][:user][:gid] = 11100
 default[:munge][:user][:name] = 'munge'
-default[:munge][:user][:uid] = 19001
-default[:munge][:user][:gid] = 19001
+default[:munge][:user][:uid] = 11101
+default[:munge][:user][:gid] = 11101

--- a/specs/default/chef/site-cookbooks/slurm/recipes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/default.rb
@@ -8,6 +8,36 @@
 slurmver = node[:slurm][:version]
 slurmarch = node[:slurm][:arch]
 slurmuser = node[:slurm][:user][:name]
+mungeuser = node[:munge][:user][:name]
+
+# Set up users for Slurm and Munge
+group slurmuser do
+  gid node[:slurm][:user][:gid]
+  not_if "getent group #{slurmuser}"  
+end
+
+user slurmuser do
+  comment 'User to run slurmd'
+  shell '/bin/false'
+  uid node[:slurm][:user][:uid]
+  gid node[:slurm][:user][:gid]
+  action :create
+end
+
+
+group mungeuser do
+  gid node[:munge][:user][:gid]
+  not_if "getent group #{mungeuser}"  
+end
+
+user mungeuser do
+  comment 'User to run munged'
+  shell '/bin/false'
+  uid node[:munge][:user][:uid]
+  gid node[:munge][:user][:gid]
+  action :create
+end
+
 
 myplatform=node[:platform]
 case myplatform
@@ -21,8 +51,8 @@ when 'ubuntu'
   # Add symlink because config path is different on ubuntu
   link '/etc/slurm' do
     to '/etc/slurm-llnl'
-    owner "#{slurmuser}"
-    group "#{slurmuser}"
+    owner slurmuser
+    group slurmuser
   end
 
   link '/bin/sinfo' do
@@ -49,50 +79,43 @@ end
 
 #Fix munge permissions and create key
 directory "/etc/munge" do
-  owner 'munge'
-  group 'munge'
+  owner mungeuser
+  group mungeuser
   mode 0700
 end
 directory "/var/lib/munge" do
-  owner 'munge'
-  group 'munge'
+  owner mungeuser
+  group mungeuser
   mode 0711
 end
 directory "/var/log/munge" do
-  owner 'munge'
-  group 'munge'
+  owner mungeuser
+  group mungeuser
   mode 0700
 end
 directory "/run/munge" do
-  owner 'munge'
-  group 'munge'
+  owner mungeuser
+  group mungeuser
   mode 0755
 end
 
 directory "/sched/munge" do
-  owner 'munge'
-  group 'munge'
+  owner mungeuser
+  group mungeuser
   mode 0700
 end
 
-# Set up slurm 
-user slurmuser do
-  comment 'User to run slurmd'
-  shell '/bin/false'
-  action :create
-end
-
 directory '/var/spool/slurmd' do
-  owner "#{slurmuser}"
+  owner slurmuser
   action :create
 end
   
 directory '/var/log/slurmd' do
-  owner "#{slurmuser}"
+  owner slurmuser
   action :create
 end
 
 directory '/var/log/slurmctld' do
-  owner "#{slurmuser}"
+  owner slurmuser
   action :create
 end

--- a/specs/default/cluster-init/tests/test_uid.py
+++ b/specs/default/cluster-init/tests/test_uid.py
@@ -1,0 +1,18 @@
+#!/opt/cycle/jetpack/system/embedded/bin/python -m pytest
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import subprocess
+import jetpack.config
+
+
+def test_slurm_uid():
+    suid = jetpack.config.get('slurm.user.uid').strip()
+    suser = jetpack.config.get('slurm.user.name').strip()
+    muid = jetpack.config.get('munge.user.uid').strip()
+    muser = jetpack.config.get('munge.user.name').strip()
+
+    # Check that slurm uid and username match what is in data store
+    subprocess.check_call(['grep', suid, '|', 'grep', suser])
+
+    # Check that munge uid and username match what is in data store
+    subprocess.check_call(['grep', muid, '|', 'grep', muser])

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -19,6 +19,14 @@ Autoscale = $Autoscale
     
         [[[configuration]]]
         slurm.version = $configuration_slurm_version
+	slurm.user.name = $configuration_slurm_user_name
+	slurm.user.uid = $configuration_slurm_user_uid
+	slurm.user.gid = $configuration_slurm_user_gid
+	munge.user.name = $configuration_munge_user_name
+	munge.user.uid = $configuration_munge_user_uid
+	munge.user.gid = $configuration_munge_user_gid
+
+	
 
         [[[cluster-init cyclecloud/slurm:default:1.0.2]]]
         Optional = true
@@ -142,10 +150,48 @@ Order = 20
     Order = 5
 
         [[[parameter configuration_slurm_version]]]
-required = True
-label = Slurm Version
-description = Version of Slurm to install on the cluster
-defaultvalue = 17.11.12-1
+	required = True
+	label = Slurm Version
+	description = Version of Slurm to install on the cluster
+	defaultvalue = 17.11.12-1
+
+	[[[parameter configuration_slurm_user_name]]]
+	required = True
+	label = Slurm Username
+	description = Username for the slurm service account
+	defaultvalue = slurm
+
+	[[[parameter configuration_slurm_user_uid]]]
+	required = True
+	label = Slurm User ID
+	description = User ID for the slurm service account
+	defaultvalue = 11100
+
+
+	[[[parameter configuration_slurm_user_gid]]]
+	required = True
+	label = Slurm Group ID
+	description = Default Group ID for the slurm service account
+	defaultvalue = 11100
+
+
+	[[[parameter configuration_munge_user_name]]]
+	required = True
+	label = Munge Username
+	description = Username for the munge service account
+	defaultvalue = munge
+
+	[[[parameter configuration_munge_user_uid]]]
+	required = True
+	label = Munge User ID
+	description = User ID for the munge service account
+	defaultvalue = 11101
+
+	[[[parameter configuration_munge_user_gid]]]
+	required = True
+	label = Munge Group ID
+	description = Default Group ID for the munge service account
+	defaultvalue = 11101
 
 
     [[parameters Software]]


### PR DESCRIPTION
Set UID/GID for slurm and munge users explicitly to remove dependency on user creation order.
This is particularly important with the new CycleCloud user management features.