### PR TITLE
Install EPEL as a dependency

### DIFF
--- a/project.ini
+++ b/project.ini
@@ -1,7 +1,7 @@
 [project]
 name = slurm
 label = Slurm
-version = 2.0.3
+version = 2.0.4
 type = scheduler
 
 [blobs]

--- a/specs/default/chef/site-cookbooks/slurm/recipes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/default.rb
@@ -87,6 +87,12 @@ when 'ubuntu'
 
 
 when 'centos'
+  # Required for munge
+  package 'epel-release'
+
+  # slurm package depends on munge
+  package 'munge'
+
   slurmrpms = %w[slurm slurm-devel slurm-example-configs slurm-slurmctld slurm-slurmd slurm-perlapi slurm-torque slurm-openlava]
   slurmrpms.each do |slurmpkg|
     jetpack_download "#{slurmpkg}-#{slurmver}.#{slurmarch}.rpm" do


### PR DESCRIPTION
Install EPEL and munge as a dependency on CentOS, so that cyclecloud-slurm
continues to work on CycleCloud 8.