### PR TITLE
Bugfix/stability 203

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/files/default/cyclecloud_slurm.py
+++ b/specs/default/chef/site-cookbooks/slurm/files/default/cyclecloud_slurm.py
@@ -295,6 +295,11 @@ def _shutdown(node_list, cluster_wrapper):
 
 
 def shutdown(node_list):
+    for node in node_list:
+        subprocess_module = _subprocess_module()
+        cmd = ["scontrol", "update", "NodeName=%s" % node, "NodeAddr=%s" % node, "NodeHostname=%s" % node]
+        logging.info("Running %s", " ".join(cmd))
+        _retry_subprocess(lambda: subprocess_module.check_call(cmd))
     return _shutdown(node_list, _get_cluster_wrapper())
 
 

--- a/specs/default/chef/site-cookbooks/slurm/templates/default/slurm.conf_centos.erb
+++ b/specs/default/chef/site-cookbooks/slurm/templates/default/slurm.conf_centos.erb
@@ -22,6 +22,7 @@ SlurmdLogFile=/var/log/slurmd/slurmd.log
 TopologyPlugin=topology/tree
 JobSubmitPlugins=job_submit/cyclecloud
 PrivateData=cloud
+TreeWidth=65533
 ResumeTimeout=<%= @resume_timeout %>
 SuspendTimeout=<%= @suspend_timeout %>
 SuspendTime=<%= @suspend_time %>

--- a/specs/default/chef/site-cookbooks/slurm/templates/default/slurm.conf_ubuntu.erb
+++ b/specs/default/chef/site-cookbooks/slurm/templates/default/slurm.conf_ubuntu.erb
@@ -22,6 +22,7 @@ SlurmdLogFile=/var/log/slurmd/slurmd.log
 TopologyPlugin=topology/tree
 JobSubmitPlugins=job_submit/cyclecloud
 PrivateData=cloud
+TreeWidth=65533
 ResumeTimeout=<%= @resume_timeout %>
 SuspendTimeout=<%= @suspend_timeout %>
 SuspendTime=<%= @suspend_time %>


### PR DESCRIPTION
Fix ping timeouts for larger clusters. Two main issues compound over time to cause nodes to start failing ping tests and kill running jobs:

1. When shutting nodes down, the NodeAddr and NodeHostname aren't being reset to their default. When IP addresses were later reused, messages from currently running nodes would instead be interpreted as being from dead nodes, and jobs would be killed. 

2. While nodes with the "CLOUD" state should force treewidth=50, that doesn't seem to be happening. As a result, ping tests were being farmed out to other slurmd's, leading to response timeouts from some nodes on clusters with more than 50 nodes.

