### PR TITLE
Remove ganglia input endpoints from template

### DIFF
--- a/templates/slurm-beegfs.txt
+++ b/templates/slurm-beegfs.txt
@@ -41,11 +41,6 @@ Autoscale = $Autoscale
         [[[network-interface eth0]]]
         AssociatePublicIpAddress = $UsePublicNetwork
 
-        [[[input-endpoint ganglia]]]
-        PrivatePort = 8652
-        PublicPort = 8652
-
-
     [[nodearray hpc]]
     MachineType = $HPCMachineType
     ImageName = $HPCImageName

--- a/templates/slurm-custom.txt
+++ b/templates/slurm-custom.txt
@@ -78,10 +78,6 @@ Autoscale = $Autoscale
         [[[network-interface eth0]]]
         AssociatePublicIpAddress = $UsePublicNetwork
 
-        [[[input-endpoint ganglia]]]
-        PrivatePort = 8652
-        PublicPort = 8652
-
         [[[volume sched]]]
         Size = 30
         SSD = True


### PR DESCRIPTION
Ganglia is no longer used by CycleCloud