### PR TITLE
update def_mem_per_cpu calculation

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/files/default/cyclecloud_slurm.py
+++ b/specs/default/chef/site-cookbooks/slurm/files/default/cyclecloud_slurm.py
@@ -247,7 +247,7 @@ def _generate_slurm_conf(partitions, writer, subprocess_module, allow_empty=Fals
             cores_per_socket = max(1, partition.vcpu_count // partition.pcpu_count)
         
         # use cores to find DefMemPerCPU to accurately configure HT VMs with "slurm.use_pcpu = false"
-        def_mem_per_cpu = memory // cores
+        def_mem_per_cpu = memory // cpus
             
         
         writer.write("# Note: CycleCloud reported a RealMemory of %d but we reduced it by %d (i.e. max(1gb, %d%%)) to account for OS/VM overhead which\n"

--- a/specs/default/chef/site-cookbooks/slurm/files/default/cyclecloud_slurm.py
+++ b/specs/default/chef/site-cookbooks/slurm/files/default/cyclecloud_slurm.py
@@ -238,7 +238,6 @@ def _generate_slurm_conf(partitions, writer, subprocess_module, allow_empty=Fals
         
         memory_to_reduce = max(1, partition.memory * partition.dampen_memory)
         memory = max(1024, int(floor((partition.memory - memory_to_reduce) * 1024)))
-        def_mem_per_cpu = memory // partition.pcpu_count
 
         if partition.use_pcpu:
             cpus = partition.pcpu_count
@@ -246,6 +245,10 @@ def _generate_slurm_conf(partitions, writer, subprocess_module, allow_empty=Fals
         else:
             cpus = partition.vcpu_count
             cores_per_socket = max(1, partition.vcpu_count // partition.pcpu_count)
+        
+        # use cores to find DefMemPerCPU to accurately configure HT VMs with "slurm.use_pcpu = false"
+        def_mem_per_cpu = memory // cores
+            
         
         writer.write("# Note: CycleCloud reported a RealMemory of %d but we reduced it by %d (i.e. max(1gb, %d%%)) to account for OS/VM overhead which\n"
                      % (int(partition.memory * 1024), int(memory_to_reduce * 1024), int(partition.dampen_memory * 100)))


### PR DESCRIPTION
formula updated to divide memory by cpus instead of pcpu to accurately calculate Hyperthreaded VMs