### PR TITLE
set slurm.use_pcpu = false for htc

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -169,6 +169,8 @@ Autoscale = $Autoscale
         [[[configuration]]]
         slurm.hpc = false
         slurm.partition = htc
+	# set pcpu = false for all hyperthreaded VMs
+	slurm.use_pcpu = false
 
 [parameters About]
 Order = 1


### PR DESCRIPTION
use vcpus for calculating cyclecloud.conf resources