### PR TITLE
Make munge.key a symlink instead of remote_file

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/recipes/execute.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/execute.rb
@@ -49,13 +49,12 @@ require 'chef/mixin/shell_out'
 
 slurmuser = node[:slurm][:user][:name]
 
-remote_file '/etc/munge/munge.key' do
-  source 'file:///sched/munge/munge.key'
+link '/etc/munge/munge.key' do
+  to '/sched/munge/munge.key'
   owner 'munge'
   group 'munge'
-  mode '0700'
-  action :create
 end
+
 
 link '/etc/slurm/slurm.conf' do
   to '/sched/slurm.conf'

--- a/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
@@ -23,12 +23,16 @@ file '/sched/munge/munge.key' do
   mode 0700
 end
 
-remote_file '/etc/munge/munge.key' do
-  source 'file:///sched/munge/munge.key'
+link '/etc/munge/munge.key' do
+  to '/sched/munge/munge.key'
   owner 'munge'
   group 'munge'
-  mode '0700'
-  action :create
+end
+
+link '/etc/slurm/slurm.conf' do
+  to '/sched/slurm.conf'
+  owner "#{slurmuser}"
+  group "#{slurmuser}"
 end
 
 service 'munge' do


### PR DESCRIPTION
Fix an issue where if someone updates /etc/munge/munge.key on the scheduler, compute nodes won't get that change since the original is still in /sched.