### PR TITLE
Bugfix - docker_rpmbuild.sh doesn't run to completion

### DIFF
--- a/specs/default/cluster-init/files/00-build-slurm.sh
+++ b/specs/default/cluster-init/files/00-build-slurm.sh
@@ -6,8 +6,6 @@ CENTOS_MAJOR=$(echo $CENTOS_VERSION | cut -d. -f1)
 
 function build_slurm() {
     set -e
-    
-    install_pmix
 
     SLURM_VERSION=$1
     SLURM_FOLDER="slurm-${SLURM_VERSION}"
@@ -33,6 +31,9 @@ function build_slurm() {
     fi
 
     yum install -y make $PYTHON which rpm-build munge-devel munge-libs readline-devel openssl openssl-devel pam-devel perl-ExtUtils-MakeMaker gcc mysql mysql-devel wget gtk2-devel.x86_64 glib2-devel.x86_64 $LIBTOOL m4 automake rsync
+    
+    install_pmix
+    
     if [ ! -e ~/bin ]; then
         mkdir -p ~/bin
     fi

--- a/specs/default/cluster-init/files/00-build-slurm.sh
+++ b/specs/default/cluster-init/files/00-build-slurm.sh
@@ -12,6 +12,13 @@ function build_slurm() {
     SLURM_PKG="slurm-${SLURM_VERSION}.tar.bz2"
     DOWNLOAD_URL="https://download.schedmd.com/slurm"
 
+    # Since EoL of Centos 8 (31st Dec 2021), need to use archived repo.
+    if [ $CENTOS_MAJOR -eq 8 ]; then
+        cd /etc/yum.repos.d/
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    fi
+
     # munge is in EPEL
     yum -y install epel-release && yum -q makecache
 
@@ -26,7 +33,7 @@ function build_slurm() {
     else
         LIBTOOL=libtool
         yum install -y dnf-plugins-core
-        yum config-manager --set-enabled PowerTools
+        yum config-manager --set-enabled powertools
         yum install -y make
     fi
 

--- a/specs/default/cluster-init/files/00-build-slurm.sh
+++ b/specs/default/cluster-init/files/00-build-slurm.sh
@@ -89,7 +89,7 @@ function install_pmix() {
     cd ../build/v3/
     ../../source/configure --prefix=/opt/pmix/v3
     make -j install >/dev/null
-    cd ../../install/v3/
+    cd ~/
 }
 
 build_slurm 20.11.7

--- a/specs/default/cluster-init/files/00-build-slurm.sh
+++ b/specs/default/cluster-init/files/00-build-slurm.sh
@@ -77,7 +77,7 @@ function build_slurm() {
 function install_pmix() {
     cd ~/
     mkdir -p /opt/pmix/v3
-    yum install -y libevent-devel git
+    yum install -y libevent-devel git flex
     mkdir -p pmix/build/v3 pmix/install/v3
     cd pmix
     git clone https://github.com/openpmix/openpmix.git source


### PR DESCRIPTION
There are a few issues with `specs/default/cluster-init/files/00-build-slurm.sh` which prevent the wrapper script from running to completion. I've tried to split these changes out into individual commits but it didn't make sense to have several PRs. The below changes lead to all the 20.11.7 .rpm/.deb files building successfully.

- The function `install_pmix` is invoked before the yum command installing its dependencies is run. Causing it to fail. Addressed in afdd7b07fcb27dab8882f5710820cde245bfd393.
- The `flex` library is needed in order to install pmix. Fixed in 8941b602d6556ab8f97e45bbd94932f6e338979e.
- The `install_pmix` function ends in `../../install/v3/` rather than `~/`. This is breaking as this context persists through to the download and extraction of slurm, causing the tar command to fail and preventing the building of the cyclecloud plugin. Fixed in 877665ef755d085a54800001881107001bf576fb.
https://github.com/Azure/cyclecloud-slurm/blob/6c788e1f11fd6ffa4c66b29aa9e6cb35074a6e25/specs/default/cluster-init/files/00-build-slurm.sh#L42-L49
- Centos 8 passed End of Life on Dec 31st 2021, and the yum mirrors built in to the latest image no longer exist. Following the instructions [here](https://techglimpse.com/failed-metadata-repo-appstream-centos-8/), we can point to `vault.centos.org` instead. This change is incompatible with the change in 3e6005fdd98d78210a1d8de6cf71aa0a2471efbb so the change made in that commit is reverted.
Implemented in 7c4edf756513d760101b3272b2e97ab9df84185d.