### PR TITLE
remove ganglia input-endpoints

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -92,10 +92,6 @@ Autoscale = $Autoscale
         [[[network-interface eth0]]]
         AssociatePublicIpAddress = $UsePublicNetwork
 
-        [[[input-endpoint ganglia]]]
-        PrivatePort = 8652
-        PublicPort = 8652
-
         [[[volume sched]]]
         Size = 30
         SSD = True


### PR DESCRIPTION
ganglia no longer used and causes the following error with HA enabled:

```
Description: InputEndpoints may not be specified with multiple placement groups. Remove InputEndpoints or set Azure.SinglePlacementGroup=True
```