### PR TITLE
Parameterise Slurm version

### DIFF
--- a/docker-rpmbuild.sh
+++ b/docker-rpmbuild.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+SLURM_VERSION=20.11.7
+
 if command -v docker; then
 
-  docker run -v $(pwd)/specs/default/cluster-init/files:/source -v $(pwd)/blobs:/root/rpmbuild/RPMS/x86_64 -ti almalinux:8.5 /bin/bash /source/00-build-slurm.sh
+  docker run -v $(pwd)/specs/default/cluster-init/files:/source -v $(pwd)/blobs:/root/rpmbuild/RPMS/x86_64 -ti almalinux:8.5 /bin/bash /source/00-build-slurm.sh $SLURM_VERSION
   docker run -v $(pwd)/specs/default/cluster-init/files:/source -v $(pwd)/blobs:/root/rpmbuild/RPMS/x86_64 -ti ubuntu:18.04 /bin/bash /source/01-build-debs.sh
   cat > /tmp/check_mising_files.py <<EOF
 from configparser import ConfigParser

--- a/specs/default/cluster-init/files/00-build-slurm.sh
+++ b/specs/default/cluster-init/files/00-build-slurm.sh
@@ -4,6 +4,7 @@ cd ~/
 
 CENTOS_VERSION=8.5
 CENTOS_MAJOR=8
+SLURM_VERSION=$1
 
 function build_slurm() {
     set -e
@@ -76,7 +77,7 @@ function build_slurm() {
     make
 
 
-    LD_LIBRARY_PATH=/root/job_submit/${SLURM_FOLDER}/src/api/.libs/ JOB_SUBMIT_CYCLECLOUD=1 python3 job_submit_cyclecloud_test.py
+    LD_LIBRARY_PATH=/root/job_submit/${SLURM_FOLDER}/src/api/.libs/ JOB_SUBMIT_CYCLECLOUD=1 SLURM_VERSION=$SLURM_VERSION python3 job_submit_cyclecloud_test.py
     rsync .libs/job_submit_cyclecloud.so  /root/rpmbuild/RPMS/x86_64/job_submit_cyclecloud_centos${CENTOS_MAJOR}_${SLURM_VERSION}-1.so
     rsync .libs/job_submit_cyclecloud.so  /root/rpmbuild/RPMS/x86_64/job_submit_cyclecloud_ubuntu_${SLURM_VERSION}-1.so
 }
@@ -100,4 +101,4 @@ function install_pmix() {
     cd ../../install/v3/
 }
 
-build_slurm 20.11.7
+build_slurm $SLURM_VERSION

--- a/specs/default/cluster-init/files/JobSubmitPlugin/job_submit_cyclecloud_test.py
+++ b/specs/default/cluster-init/files/JobSubmitPlugin/job_submit_cyclecloud_test.py
@@ -74,8 +74,9 @@ def generate_job_descriptor_class(lines):
         _fields_ = fields
     return job_descriptor
 
+SLURM_VERSION = os.environ.get('SLURM_VERSION')
 
-SLURM_H_PATH = os.path.expanduser("~/job_submit/slurm-20.11.7/slurm/slurm.h")
+SLURM_H_PATH = os.path.expanduser(f"~/job_submit/slurm-{SLURM_VERSION}/slurm/slurm.h")
 if os.getenv("SLURM_H_PATH", ""):
     SLURM_H_PATH = os.environ["SLURM_H_PATH"]
 


### PR DESCRIPTION
Removing hard-coded Slurm versions from `00-build-slurm.sh` and `job_submit_cyclecloud_test.py` to ease building of multiple versions. Moved version out to variable in `docker-rpmbuild.sh` instead.