### PR TITLE
slurm.use_pcpu changes for HT VM

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
@@ -10,6 +10,7 @@ default[:cyclecloud][:hosts][:simple_vpc_dns][:enabled] = false
 default[:cyclecloud][:hosts][:standalone_dns][:enabled] = false
 default[:slurm][:additional][:config] = ""
 default[:slurm][:ensure_waagent_monitor_hostname] = true
+default[:slurm][:use_pcpu] = false
 
 myplatform=node[:platform_family]
 case myplatform

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -187,8 +187,6 @@ Autoscale = $Autoscale
         [[[configuration]]]
         slurm.hpc = false
         slurm.partition = htc
-	# set pcpu = false for all hyperthreaded VMs
-	slurm.use_pcpu = false
 
 [parameters About]
 Order = 1


### PR DESCRIPTION
remove `slurm.use_pcpu=false` from template htc nodearray and place it as default setting in `default.rb`