### PR TITLE
add exports.builtinsched.disabled = ${NFSSchedDisable} for HA

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -117,6 +117,7 @@ Autoscale = $Autoscale
         fs_type = xfs
 
         [[[configuration cyclecloud.exports.builtinsched]]]
+	disabled = ${NFSSchedDisable}
         export_path = /sched
         options = no_root_squash
         samba.enabled = false


### PR DESCRIPTION
disable the export if an external Sched is used as required for HA config