### PR TITLE
login recipe missing link to keep_alive.conf

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/recipes/login.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/login.rb
@@ -51,6 +51,12 @@ link '/etc/slurm/gres.conf' do
   only_if { ::File.exist?('/sched/gres.conf') }
 end
 
+link '/etc/slurm/keep_alive.conf' do
+  to '/sched/keep_alive.conf'
+  owner "#{slurmuser}"
+  group "#{slurmuser}"
+end
+
 service 'munge' do
   action [:enable, :restart]
 end


### PR DESCRIPTION
On release 2.7.0 the Login node does not work with following error:

```
sinfo: error: s_p_parse_file: cannot stat file /etc/slurm/keep_alive.conf: No such file or directory, retrying in 1sec up to 60sec
```

Updated the login recipe to link the `keep_alive.conf` file