### PR TITLE
Update default instance type

### DIFF
--- a/templates/slurm-beegfs.txt
+++ b/templates/slurm-beegfs.txt
@@ -110,7 +110,7 @@ Order = 10
         Label = Scheduler VM Type
         Description = The VM type for scheduler node
         ParameterType = Cloud.MachineType
-        DefaultValue = Standard_D12_v2
+        DefaultValue = Standard_E4_v4
 
         [[[parameter HPCMachineType]]]
         Label = HPC VM Type

--- a/templates/slurm-custom.txt
+++ b/templates/slurm-custom.txt
@@ -183,7 +183,7 @@ Order = 10
         Label = Scheduler VM Type
         Description = The VM type for scheduler node
         ParameterType = Cloud.MachineType
-        DefaultValue = Standard_D12_v2
+        DefaultValue = Standard_E4_v4
 
         [[[parameter HPCMachineType]]]
         Label = HPC VM Type

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -220,7 +220,7 @@ Order = 10
         Label = Scheduler VM Type
         Description = The VM type for scheduler node
         ParameterType = Cloud.MachineType
-        DefaultValue = Standard_D12_v2
+        DefaultValue = Standard_E4_v4
 
         [[[parameter loginMachineType]]]
         Label = Login node VM Type


### PR DESCRIPTION
Change D12_v2 to D16_v4, better default price / performance value and supports hyperv gen2.

gen 2 support matrix: https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2