### PR TITLE
Slurm accounting with cost reporting

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,9 @@
-mypy==0.790
+mypy
 autoflake==1.3.1
 black==20.8b1
 pytest
+tabulate
 flake8
 hypothesis
 isort==4.3.21
-typing_extensions==3.6.6
+typing_extensions==3.7.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-mypy
+mypy==0.790
 autoflake==1.3.1
 black==20.8b1
 pytest
@@ -6,4 +6,4 @@ tabulate
 flake8
 hypothesis
 isort==4.3.21
-typing_extensions==3.7.4
+typing_extensions==3.6.6

--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,7 @@ azslurm initconfig --username $(jetpack config cyclecloud.config.username) \
                    --accounting-tag-name ClusterId \
                    --accounting-tag-value $tag \
                    --accounting-subscription-id $(jetpack config azure.metadata.compute.subscriptionId) \
+                   --cost-cache-root $INSTALL_DIR/.cache \
                    > $INSTALL_DIR/autoscale.json
 
 

--- a/package.py
+++ b/package.py
@@ -151,6 +151,7 @@ def execute() -> None:
 
     _add("install.sh", mode=os.stat("install.sh")[0])
     _add("sbin/resume_fail_program.sh", "sbin/resume_fail_program.sh")
+    _add("sbin/prolog.sh", "sbin/prolog.sh")
     _add("sbin/resume_program.sh", "sbin/resume_program.sh")
     _add("sbin/return_to_idle.sh", "sbin/return_to_idle.sh")
     _add("sbin/suspend_program.sh", "sbin/suspend_program.sh")

--- a/sbin/prolog.sh
+++ b/sbin/prolog.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -x
+
+log=/var/log/slurmctld/prolog_slurmctld.log
+script=/opt/azurehpc/slurm/get_acct_info.sh
+scontrol=/bin/scontrol
+JQ=/bin/jq
+job=$SLURM_JOBID
+
+nodename=$($scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
+
+ret=0
+count=0
+
+while [ $ret -eq 0 ] && [ $count -lt 5 ]
+do
+	sleep 2
+	output=$($script $nodename 2>>$log)
+	ret=$(echo $output | $JQ '. | length')
+	echo "DEBUG: json: " $output "ret: " $ret "job: " $SLURM_JOBID "nodename: " $nodename >> $log
+	count=$((count+1))
+done
+
+if [ $ret -eq 0 ]; then
+	echo "ERROR: Could not process get node info for admincomment" >> $log
+else
+	$scontrol update job=$job admincomment="$output"
+fi

--- a/slurm/conf/logging.conf
+++ b/slurm/conf/logging.conf
@@ -58,6 +58,12 @@ level=INFO
 formatter=reproFormatter
 args=("/opt/azurehpc/slurm/logs/autoscale_repro.log", "a", 1024 * 1024 * 5, 5)
 
+[handler_costFileHandler]
+class=logging.handlers.RotatingFileHandler
+level=DEBUG
+formatter=reproFormatter
+args=("/opt/azurehpc/slurm/logs/cost.log", "a", 1024 * 1024 * 5, 5)
+
 [handler_consoleHandler]
 class=StreamHandler
 level=ERROR

--- a/slurm/conf/logging.conf
+++ b/slurm/conf/logging.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root, repro, slurm_driver, demand
+keys=root, repro, slurm_driver, demand, cost
 
 [handlers]
-keys=consoleHandler, fileHandler, reproFileHandler, qcmdHandler, demandHandler, suspendHandler, resumeHandler, resume_failHandler
+keys=consoleHandler, fileHandler, reproFileHandler, qcmdHandler, demandHandler, suspendHandler, resumeHandler, resume_failHandler, costFileHandler
 
 [formatters]
 keys=simpleFormatter, reproFormatter
@@ -34,6 +34,11 @@ qualname=demand
 level=DEBUG
 handlers=demandHandler
 
+[logger_cost]
+qualname=cost
+level=DEBUG
+handlers=costFileHandler
+
 [handler_fileHandler]
 class=logging.handlers.RotatingFileHandler
 level=DEBUG
@@ -61,7 +66,7 @@ args=("/opt/azurehpc/slurm/logs/autoscale_repro.log", "a", 1024 * 1024 * 5, 5)
 [handler_costFileHandler]
 class=logging.handlers.RotatingFileHandler
 level=DEBUG
-formatter=reproFormatter
+formatter=simpleFormatter
 args=("/opt/azurehpc/slurm/logs/cost.log", "a", 1024 * 1024 * 5, 5)
 
 [handler_consoleHandler]

--- a/slurm/install/install.py
+++ b/slurm/install/install.py
@@ -170,6 +170,7 @@ def accounting(s: InstallSettings) -> None:
         content="""
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost="localhost"
+AccountingStorageTRES=gres/gpu
 """,
     )
     subprocess.check_call(

--- a/slurm/install/install.py
+++ b/slurm/install/install.py
@@ -201,7 +201,7 @@ AccountingStorageHost="localhost"
         variables={
             "accountdb": s.acct_url or "localhost",
             "dbuser": s.acct_user or "root",
-            "storagepass": "StoragePass={s.acct_pass}" if s.acct_pass else "#StoragePass=",
+            "storagepass": f"StoragePass={s.acct_pass}" if s.acct_pass else "#StoragePass=",
             "slurmver": s.slurmver,
         },
     )

--- a/slurm/install/templates/slurm.conf.template
+++ b/slurm/install/templates/slurm.conf.template
@@ -26,6 +26,7 @@ SlurmdLogFile=/var/log/slurmd/slurmd.log
 # or just add --switches 1 to your submission scripts
 # JobSubmitPlugins=lua
 PrivateData=cloud
+PrologSlurmctld=/opt/azurehpc/slurm/prolog.sh
 TreeWidth=65533
 ResumeTimeout=1800
 SuspendTimeout=600

--- a/slurm/setup.py
+++ b/slurm/setup.py
@@ -127,7 +127,7 @@ setup(
             "../notices",
         ]
     },
-    install_requires=["typing_extensions==3.7.4.3", "certifi==2020.12.5", "zipp==3.6"],
+    install_requires=["typing_extensions==3.7.4.3", "certifi==2020.12.5", "zipp==3.6", "tabulate"],
     tests_require=["pytest==3.2.3"],
     cmdclass={"test": PyTest, "format": Formatter, "types": TypeChecking},
     url="http://www.cyclecomputing.com",

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -150,7 +150,7 @@ class SlurmCLI(CommonCLI):
         to SLURM Job Accounting data. This is an experimental
         feature.
         """
-        config['cache_root'] = "/tmp"
+
         curr = datetime.today()
         delta = timedelta(days=365)
 
@@ -352,6 +352,7 @@ class SlurmCLI(CommonCLI):
         parser.add_argument(
             "--accounting-subscription-id", dest="accounting__subscription_id"
         )
+        parser.add_argument("--cost-cache-root", dest="cost__cache_root")
 
     def _initconfig(self, config: Dict) -> None:
         # TODO

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 import time
 from argparse import ArgumentParser
-from datetime import date,datetime,timedelta
+from datetime import date,datetime,timedelta,time
 from math import ceil
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, TextIO, Union
 

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -164,8 +164,6 @@ class SlurmCLI(CommonCLI):
             raise ValueError("End date cannot be in the future")
         if start == end:
             end = datetime.combine(end.date(), time(hour=23,minute=59,second=59))
-        logging.debug(f"start: {start}")
-        logging.debug(f"end: {end}")
 
         azcost = azurecost(config)
         driver = cost.CostDriver(azcost, config)

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -139,13 +139,12 @@ class SlurmCLI(CommonCLI):
         parser.add_argument("-e", "--end",  type=lambda s: datetime.strptime(s, '%Y-%m-%d'),
                             default=date.today().isoformat(),
                             help="End time period (yyyy-mm-dd), defaults to current day.")
-        parser.add_argument("-o", "--out", required=True, help="Fully qualified output filename")
+        parser.add_argument("-o", "--out", required=True, help="Directory name for output CSV")
+        #parser.add_argument("-p", "--partition", action='store_true', help="Show costs aggregated by partitions")
+        parser.add_argument("-f", "--fmt", type=str,
+                            help="Comma separated list of SLURM formatting options. Otherwise defaults are applied")
 
-        #parser.add_argument("--partition", action='store_true', help="Show costs aggregated by partitions")
-        #parser.add_argument("--user", action='store_true', help="Show costs aggregated by user")
-        #parser.add_argument("-f", "--fmt", type=str, help="Comma separated list of formatting options")
-
-    def cost(self, config: Dict, start, end, out):
+    def cost(self, config: Dict, start, end, out, fmt=None):
         """
         Cost analysis and reporting tool that maps Azure costs
         to SLURM Job Accounting data. This is an experimental
@@ -167,7 +166,7 @@ class SlurmCLI(CommonCLI):
 
         azcost = azurecost(config)
         driver = cost.CostDriver(azcost, config)
-        driver.run(start, end, out)
+        driver.run(start, end, out, fmt)
 
     def partitions_parser(self, parser: ArgumentParser) -> None:
         parser.add_argument("--allow-empty", action="store_true", default=False)

--- a/slurm/src/slurmcc/cost.py
+++ b/slurm/src/slurmcc/cost.py
@@ -1,0 +1,219 @@
+import os
+import json
+import csv
+from tabulate import tabulate
+from datetime import datetime
+import hpc.autoscale.hpclogging as log
+from collections import namedtuple
+from hpc.autoscale.cost.azurecost import azurecost
+from .util import run_command
+
+def get_sacct_fields():
+
+    options = []
+    cmd = "/usr/bin/sacct -e"
+    out = run_command(cmd)
+    for line in out.stdout.split('\n'):
+        for opt in line.split():
+            options.append(opt.lower())
+
+    return options
+
+class Statistics:
+
+    def __init__(self):
+
+        self.jobs = 0
+        self.running_jobs = 0
+        self.processed = 0
+        self.unprocessed = 0
+        self.cost_per_sku = {}
+        self.admincomment_err = 0
+
+    def display(self):
+
+        table = []
+        table.append(['Total Jobs', self.jobs])
+        table.append(['Total Processed Jobs', self.processed])
+        table.append(['Total processed running jobs', self.running_jobs])
+        table.append(['Unprocessed Jobs', self.unprocessed])
+        table.append(['Jobs with admincomment errors', self.admincomment_err])
+        print(tabulate(table, headers=['SUMMARY',''], tablefmt="simple"))
+
+class CostSlurm:
+    def __init__(self, start:str, end: str, cluster: str) -> None:
+
+        self.start = start
+        self. end = end
+        self.cluster = cluster
+        self.sacct = "/usr/bin/sacct"
+        self.squeue = "/usr/bin/squeue"
+        self.sacctmgr = "/usr/bin/sacctmgr"
+        cache_root = "/tmp"
+        self.stats = Statistics()
+        self.cache = f"{cache_root}/slurm"
+        try:
+            os.makedirs(self.cache, 0o777, exist_ok=True)
+        except OSError as e:
+            log.error("Unable to create cache directory {self.cache}")
+            log.error(e.strerror)
+            raise
+        self.DEFAULT_SLURM_FORMAT = "jobid,user,account,cluster,partition,ncpus,nnodes,submit,start,end,elapsedraw,state,admincomment"
+        self.options = "--allusers --duplicates --parsable2 --allocations --noheader"
+        #TODO fix this later
+        self.slurm_avail_fmt = self.DEFAULT_SLURM_FORMAT
+        self.slurm_fmt_t = namedtuple('slurm_fmt_t', self.DEFAULT_SLURM_FORMAT)
+        self.c_fmt_t = namedtuple('c_fmt_t', ['cost'])
+
+    def get_slurm_format(self):
+
+        return ','.join(self.DEFAULT_SLURM_FORMAT)
+
+    def _construct_command(self) -> str:
+
+        args = f"{self.sacct} {self.options} " \
+                f"-M {self.cluster} "\
+                f"--start={self.start} " \
+                f"--end={self.end} -o "\
+                f"{self.DEFAULT_SLURM_FORMAT}"
+        return args
+
+    def use_cache(self, filename) -> bool:
+        return False
+
+    def get_queue_rec_file(self) -> str:
+        return os.path.join(self.cache, f"queue.out")
+
+    def get_job_rec_file(self) -> str:
+        return os.path.join(self.cache, f"sacct-{self.start}-{self.end}.out")
+
+    def get_queue_records(self) -> str:
+
+        _queue_rec_file = self.get_queue_rec_file()
+        if self.use_cache(_queue_rec_file):
+            return _queue_rec_file
+
+        cmd = f"{self.squeue} --json"
+        with open(_queue_rec_file, 'w') as fp:
+            output = run_command(cmd, stdout=fp)
+            if output.returncode:
+                log.error("could not read slurm queue")
+        return _queue_rec_file
+
+    def process_queue(self) -> dict:
+        running_jobs = {}
+        queue_rec = self.get_queue_records()
+        with open(queue_rec, 'r') as fp:
+            data = json.load(fp)
+
+        for job in data['jobs']:
+            if job['job_state'] != 'RUNNING' and job['job_state'] != 'CONFIGURING':
+                continue
+            job_id = job['job_id']
+            if job['admin_comment']:
+                running_jobs[job_id] = job['admin_comment']
+        return running_jobs
+
+    def fetch_job_records(self) -> str:
+
+        _job_rec_file = self.get_job_rec_file()
+        if self.use_cache(_job_rec_file):
+            return _job_rec_file
+        cmd = self._construct_command()
+        with open(_job_rec_file, 'w') as fp:
+            output = run_command(cmd, stdout=fp)
+            if output.returncode:
+                log.error("Could not fetch slurm records")
+        return _job_rec_file
+
+    def parse_admincomment(self, comment: str):
+
+        return json.loads(comment)
+
+    def get_output_format(self, azcost: azurecost):
+
+        az_fmt = azcost.get_azcost_job_format()
+        #slurm_fmt =  self.get_slurm_format()
+
+        return namedtuple('out_fmt_t', list(self.slurm_fmt_t._fields + az_fmt._fields + self.c_fmt_t._fields))
+
+    def process_jobs(self, azcost: azurecost, jobsfp, out_fmt_t):
+
+        _job_rec_file = self.fetch_job_records()
+        running = self.process_queue()
+        fp = open(_job_rec_file, newline='')
+        reader = csv.reader(fp, delimiter='|')
+        writer = csv.writer(jobsfp, delimiter=',')
+
+        for row in map(self.slurm_fmt_t._make, reader):
+            self.stats.jobs += 1
+            if row.state == 'RUNNING' and int(row.jobid) in running:
+                admincomment = running[int(row.jobid)]
+                self.stats.running_jobs += 1
+            else:
+                admincomment = row.admincomment
+            try:
+                comment_d = self.parse_admincomment(admincomment)[0]
+                sku_name = comment_d['vm_size']
+                cpupernode = comment_d['pcpu_count']
+                region = comment_d['location']
+                spot = comment_d['spot']
+            except json.JSONDecodeError as e:
+                log.debug(f"Cannot parse admincomment job={row.jobid} cluster={row.cluster}")
+                self.stats.admincomment_err += 1
+                self.stats.unprocessed += 1
+                continue
+            charge_factor = float(row.ncpus) / float(cpupernode)
+
+            az_fmt = azcost.get_azcost_job(sku_name, region, spot)
+            charged_cost = ((az_fmt.rate/3600) * float(row.elapsedraw)) * charge_factor
+            c_fmt = self.c_fmt_t(cost=charged_cost)
+            if (region,sku_name) not in self.stats.cost_per_sku:
+                self.stats.cost_per_sku[(region,sku_name)] = 0
+            self.stats.cost_per_sku[(region,sku_name)] += charged_cost
+
+            out_row = []
+            for f in out_fmt_t._fields:
+                if f in self.slurm_fmt_t._fields:
+                    out_row.append(row._asdict()[f])
+                elif f in az_fmt._fields:
+                    out_row.append(az_fmt._asdict()[f])
+                elif f in self.c_fmt_t._fields:
+                    out_row.append(c_fmt._asdict()[f])
+                else:
+                    log.error(f"encountered an unexpected field {f}")
+
+            writer.writerow(out_row)
+            self.stats.processed += 1
+        fp.close()
+
+class CostDriver:
+    def __init__(self, azcost: azurecost, config: dict):
+
+        self.azcost = azcost
+        self.cluster = config['cluster_name']
+
+    def run(self, start: datetime, end: datetime, out: str):
+
+        sacct_start = start.isoformat()
+        sacct_end = end.isoformat()
+        cost_slurm = CostSlurm(start=sacct_start, end=sacct_end, cluster=self.cluster)
+        os.makedirs(out, exist_ok=True)
+
+        jobs_csv = os.path.join(out, "jobs.csv")
+        part_csv = os.path.join(out, "partition.csv")
+        part_hourly = os.path.join(out, "partition_hourly.csv")
+
+        fmt = self.azcost.get_azcost_job_format()
+        out_fmt_t = cost_slurm.get_output_format(self.azcost)
+        with open(jobs_csv, 'w') as fp:
+            writer = csv.writer(fp, delimiter=',')
+            writer.writerow(list(out_fmt_t._fields))
+            cost_slurm.process_jobs(azcost=self.azcost, jobsfp=fp, out_fmt_t=out_fmt_t)
+
+        fmt = self.azcost.get_azcost_nodearray_format()
+        with open(part_csv, 'w') as fp:
+            writer = csv.writer(fp, delimiter=',')
+            writer.writerow(list(fmt._fields))
+            count = self.azcost.get_azcost_nodearray(fp, start=sacct_start, end=sacct_end)
+        cost_slurm.stats.display()

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -9,6 +9,21 @@ from . import custom_chaos_mode
 
 from . import CyclecloudSlurmError
 
+def run_command(cmd: str, stdout=subprocesslib.PIPE, stderr=subprocesslib.PIPE):
+    """
+    run arbitrary command
+    """
+    cmd_list = cmd.split(' ')
+    logging.debug(cmd_list)
+    try:
+        output = subprocesslib.run(cmd_list,stdout=stdout,stderr=stderr, check=True,
+                       encoding='utf-8')
+    except subprocesslib.CalledProcessError as e:
+        logging.error(f"cmd: {e.cmd}, rc: {e.returncode}")
+        logging.error(e.stderr)
+        raise
+    logging.debug(f"output: {output.stdout}")
+    return output
 
 def to_hostlist(nodes: Union[str, List[str]]) -> str:
     """

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -9,22 +9,6 @@ from . import custom_chaos_mode
 
 from . import CyclecloudSlurmError
 
-def run_command(cmd: str, stdout=subprocesslib.PIPE, stderr=subprocesslib.PIPE):
-    """
-    run arbitrary command
-    """
-    cmd_list = cmd.split(' ')
-    logging.debug(cmd_list)
-    try:
-        output = subprocesslib.run(cmd_list,stdout=stdout,stderr=stderr, check=True,
-                       encoding='utf-8')
-    except subprocesslib.CalledProcessError as e:
-        logging.error(f"cmd: {e.cmd}, rc: {e.returncode}")
-        logging.error(e.stderr)
-        raise
-    logging.debug(f"output: {output.stdout}")
-    return output
-
 def to_hostlist(nodes: Union[str, List[str]]) -> str:
     """
     convert name-[1-5] into name-1 name-2 name-3 name-4 name-5

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -9,6 +9,7 @@ from . import custom_chaos_mode
 
 from . import CyclecloudSlurmError
 
+
 def to_hostlist(nodes: Union[str, List[str]]) -> str:
     """
     convert name-[1-5] into name-1 name-2 name-3 name-4 name-5


### PR DESCRIPTION
Adds cost reporting to slurm accounting and creates a new `azslurm cost` CLI to append costs to slurm accounting data.

Also adds a prolog slurmctld script that records vm size related information such as sku, region, priority, cpu/gpu counts etc and stores them in admincomment field in slurm, so that cost reporting can fetch relevant cost data.