### PR TITLE
Fix login nodes and Remove unused chef recipes

### DIFF
--- a/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
+++ b/specs/default/chef/site-cookbooks/slurm/recipes/scheduler.rb
@@ -1,9 +1,0 @@
-#
-# Cookbook Name:: slurm
-# Recipe:: scheduler
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-include_recipe 'slurm::default'
-
-# TODO run configurator

--- a/specs/default/cluster-init/files/install-non-scheduler.sh
+++ b/specs/default/cluster-init/files/install-non-scheduler.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+mode=$1
+echo $mode | grep -Eqw "login|execute" || (echo "Usage: $0 [login|execute]" && exit 1)
+
+do_install=$(jetpack config slurm.do_install True)
+install_pkg=$(jetpack config slurm.install_pkg azure-slurm-install-pkg-3.0.1.tar.gz)
+slurm_project_name=$(jetpack config slurm.project_name slurm)
+platform=$(jetpack config platform_family rhel)
+dynamic_config=$(jetpack config slurm.dynamic_config _none_)
+
+
+cd $CYCLECLOUD_HOME/system/bootstrap
+if [ $do_install == "True" ]; then
+
+    jetpack download --project $slurm_project_name $install_pkg
+    tar xzf $install_pkg
+    cd azure-slurm-install
+    python3 install.py --platform $platform --mode $mode --bootstrap-config /opt/cycle/jetpack/config/node.json
+fi
+
+systemctl restart munge
+# wait up to 60 seconds for munge to start
+iters=60
+while [ $iters -ge 0 ]; do
+    echo test | munge > /dev/null 2>&1
+    if [ $? == 0 ]; then
+        break
+    fi
+    sleep 1
+    iters=$(( $iters - 1 ))
+done
+
+if [ "$mode" == "execute" ]; then
+    if [ "$dynamic_config" != "_none_" ]; then
+        delete_dynamic_node=$(jetpack config slurm.delete_dynamic_node True)
+        if [ "$delete_dynamic_node" == "True" ]; then
+            node_name=$(jetpack config cyclecloud.node.name)
+            echo "Deleting dynamic node $node_name"
+
+            scontrol delete nodename=$node_name
+        fi
+    fi
+
+    systemctl start slurmd
+fi

--- a/specs/execute/cluster-init/scripts/00-install-execute.sh
+++ b/specs/execute/cluster-init/scripts/00-install-execute.sh
@@ -1,29 +1,3 @@
 #!/usr/bin/env bash
 set -e
-do_install=$(jetpack config slurm.do_install True)
-install_pkg=$(jetpack config slurm.install_pkg azure-slurm-install-pkg-3.0.1.tar.gz)
-slurm_project_name=$(jetpack config slurm.project_name slurm)
-platform=$(jetpack config platform_family rhel)
-
-cd $CYCLECLOUD_HOME/system/bootstrap
-if [ $do_install == "True" ]; then
-    
-    jetpack download --project $slurm_project_name $install_pkg
-    tar xzf $install_pkg
-    cd azure-slurm-install
-    python3 install.py --platform $platform --mode execute --bootstrap-config /opt/cycle/jetpack/config/node.json
-fi
-
-systemctl restart munge
-# wait up to 60 seconds for munge to start
-iters=60
-while [ $iters -ge 0 ]; do
-    echo test | munge > /dev/null 2>&1
-    if [ $? == 0 ]; then
-        break
-    fi
-    sleep 1
-    iters=$(( $iters - 1 ))
-done
-
-systemctl start slurmd
+$SHELL /mnt/cluster-init/slurm/default/files/install-non-scheduler.sh execute

--- a/specs/login/cluster-init/scripts/00-install-login.sh
+++ b/specs/login/cluster-init/scripts/00-install-login.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+$SHELL /mnt/cluster-init/slurm/default/files/install-non-scheduler.sh login


### PR DESCRIPTION
Run slurm installation on login nodes, so slurm binaries are accessible from login nodes. Allows users to run `squeue`, `srun` etc from the logins.