### PR TITLE
Fix SSL certificates used for accounting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ if [ ! -e blobs ]; then
     mkdir blobs
 fi
 
+wget -k -O slurm/install/AzureCA.pem  https://github.com/Azure/cyclecloud-slurm/releases/download/2.7.3/AzureCA.pem
 # ls slurm/install/slurm-pkgs/*.rpm > /dev/null || (echo you need to run docker-rpmbuild.sh first; exit 1)
 # ls slurm/install/slurm-pkgs/*.deb > /dev/null || (echo you need to run docker-rpmbuild.sh first; exit 1)
 

--- a/slurm/install/package.py
+++ b/slurm/install/package.py
@@ -85,6 +85,7 @@ def execute() -> None:
     _add("install.py", "install.py")
     _add("ubuntu.sh", "ubuntu.sh", 600)
     _add("rhel.sh", "rhel.sh", 600)
+    _add("AzureCA.pem", "AzureCA.pem")
 
     for fil in os.listdir("templates"):
         if os.path.isfile(f"templates/{fil}"):

--- a/slurm/install/templates/slurmdbd.conf.template
+++ b/slurm/install/templates/slurmdbd.conf.template
@@ -32,4 +32,4 @@ StorageType=accounting_storage/mysql
 StorageHost={accountdb}
 {storagepass}
 StorageUser={dbuser}
-StorageParameters=SSL_CA=/etc/slurm/BaltimoreCyberTrustRoot.crt.pem
+StorageParameters=SSL_CA=/etc/slurm/AzureCA.pem

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -29,6 +29,7 @@ Autoscale = $Autoscale
         slurm.accounting.url = $configuration_slurm_accounting_url
         slurm.accounting.user = $configuration_slurm_accounting_user
         slurm.accounting.password = $configuration_slurm_accounting_password
+        slurm.accounting.certificate_url = $configuration_slurm_accounting_certificate_url
         slurm.additional.config = $additional_slurm_config
         slurm.ha_enabled = $configuration_slurm_ha_enabled
         slurm.launch_parameters = $configuration_slurm_launch_parameters


### PR DESCRIPTION
Azure Maria DB now requires combined SSL client certificates from 2 authorities. . This PR fixes the client certificates used by Azure Maria DB, and also adds a new certificate_url option for user to specify the certificate. If a user has specified certificate then it is used.

 The issue is described here: https://learn.microsoft.com/en-us/azure/mariadb/concepts-certificate-rotation?WT.mc_id=Portal-SqlAzureExtension