### PR TITLE
Add "-b" to  slurmd config for dynamic nodes

### DIFF
--- a/slurm/install/install.py
+++ b/slurm/install/install.py
@@ -371,6 +371,9 @@ def setup_slurmd(s: InstallSettings) -> None:
     slurmd_config = f"SLURMD_OPTIONS=-b -N {s.node_name}"
     if s.dynamic_config:
         slurmd_config = f"SLURMD_OPTIONS={s.dynamic_config} -N {s.node_name}"
+        if "-b" not in slurmd_config.split():
+            slurmd_config = slurmd_config + " -b"
+
     ilib.file(
         "/etc/sysconfig/slurmd" if s.platform_family == "rhel" else "/etc/default/slurmd",
         content=slurmd_config,


### PR DESCRIPTION
Slurmd on dynamic nodes needs to start with "-b" if its not already been specified in the template.