### PR TITLE
Prevent querying for dynamic node names while slurmctld is down.

### DIFF
--- a/slurm/src/slurmcc/partition.py
+++ b/slurm/src/slurmcc/partition.py
@@ -93,6 +93,9 @@ class Partition:
             return slutil.to_hostlist(self._static_all_nodes())
         # with dynamic nodes, we only look at those defined in the partition
         if not self.__dynamic_node_list_cache:
+            if not slutil.is_slurmctld_up():
+                logging.warning("While slurmctld is down, dynamic nodes can not be queried at this time.")
+                return ""
             ret: List[str] = []
             all_slurm_nodes = Partition._slurm_nodes()
             for node in all_slurm_nodes:

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -38,6 +38,14 @@ def scontrol(args: List[str], retry: bool = True) -> str:
     return SLURM_CLI.scontrol(args, retry)
 
 
+def is_slurmctld_up() -> bool:
+    try:
+        SLURM_CLI.scontrol(["ping"], retry=False)
+        return True
+    except Exception:
+        return False
+
+
 def show_nodes(node_list: Optional[List[str]] = None) -> List[Dict[str, Any]]:
     args = ["show", "nodes"]
     if node_list:


### PR DESCRIPTION
Prevents querying of node names while scontrol is down

Regression from PR 138