### PR TITLE
Do not restart slurmctld for configuration updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ Slurm is a highly configurable open source workload manager. See the [Slurm proj
 See [Transitioning from 2.7 to 3.0](#transitioning-from-27-to-30) for more information.
 
 ### Making Cluster Changes
-The Slurm cluster deployed in CycleCloud contains a cli called `azslurm` which facilitates this. After making any changes to the cluster, run the following command as root on the Slurm scheduler node to rebuild the `azure.conf` and update the nodes in the cluster:
+The Slurm cluster deployed in CycleCloud contains a cli called `azslurm` which facilitates this. After making any changes to the cluster such as updating VM sizes or changing node counts, run the following command as root on the Slurm scheduler node to rebuild the `azure.conf` and `gres.conf`.
 
 ```
       $ sudo -i
       # azslurm scale
 ```
 
-This should create the partitions with the correct number of nodes, the proper `gres.conf` and restart the `slurmctld`.
+This should re-create the partition and node information with the correct number of nodes, the proper `gres.conf`.
+Note: changes to static partitions may require user to restart slurmctld `systemctl restart slurmctld`. 
 
 ### No longer pre-creating execute nodes
 As of 3.0.0, we are no longer pre-creating the nodes in CycleCloud. Nodes are created when `azslurm resume` is invoked, or by manually creating them in CycleCloud via CLI etc.

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -428,7 +428,7 @@ class SlurmCLI(CommonCLI):
             msg = f"{linked_gres_conf} should be a symlink to {gres_conf}! Changes will not take effect locally."
             print("WARNING: " + msg, file=sys.stderr)
             logging.warning(msg)
-        
+
         if not os.path.exists(linked_gres_conf):
             msg = f"please run 'ln -s {gres_conf} {linked_gres_conf}' && chown slurm:slurm {linked_gres_conf}"
             print("WARNING: " + msg, file=sys.stderr)
@@ -458,9 +458,8 @@ class SlurmCLI(CommonCLI):
             _generate_gres_conf(partition_dict, fw)
         shutil.move(gres_conf + ".tmp", gres_conf)
 
-        logging.info("Restarting slurmctld...")
-        check_output(["systemctl", "restart", "slurmctld"])
-
+        msg = f"Warning: For changes impacting non-dynamic partitions, please run `systemctl restart slurmctld` for changes to take effect."
+        print(msg)
         logging.info("")
         logging.info("Re-scaling cluster complete.")
 


### PR DESCRIPTION
azslurm scale is used for updating dynamic nodes and other slurm configurations. But not all changes (especially dynamic nodes) require restarting slurmctld. Restarting slurmctld should be left upto the user. Doing it on behalf of the user especially for a use case that is perfectly supported without having to restart slurmctld, can be quite disruptive. For other use cases, we should just print a warning message.