### PR TITLE
Prolog slurmctld script needs to use correct binaries.

### DIFF
--- a/sbin/prolog.sh
+++ b/sbin/prolog.sh
@@ -3,8 +3,19 @@ set -x
 
 log=/var/log/slurmctld/prolog_slurmctld.log
 script=/opt/azurehpc/slurm/get_acct_info.sh
-scontrol=/bin/scontrol
-JQ=/bin/jq
+
+if [ -e /bin/scontrol ]; then
+	scontrol=/bin/scontrol
+elif [ -e /usr/bin/scontrol ]; then
+	scontrol=/usr/bin/scontrol
+fi
+
+if [ -e /bin/jq ]; then
+	JQ=/bin/jq
+elif [ -e /usr/bin/jq ]; then
+	JQ=/usr/bin/jq
+fi
+
 job=$SLURM_JOBID
 
 nodename=$($scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)


### PR DESCRIPTION
Slurm binaries can be present under /bin or /usr/bin.