### PR TITLE
For dynamic partition make config.MultiSelect true by default.

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -265,6 +265,7 @@ Order = 10
         Description = The VM type for Dynamic execute nodes
         ParameterType = Cloud.MachineType
         DefaultValue = Standard_F2s_v2
+        Config.MultiSelect = true
 
 
     [[parameters Auto-Scaling]]


### PR DESCRIPTION
For dynamic partitions having the default of allowing multiple VM sizes as default makes them more useful.