### PR TITLE
Add Dockerfile for building azslurm packages.

### DIFF
--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -1,0 +1,4 @@
+FROM almalinux:8.5
+
+RUN yum install -y python36 wget git
+


### PR DESCRIPTION
Dockerfile caches the basic build environment, for faster building.