### PR TITLE
Update slurm versions and use new artifacts created via ADO.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,13 +334,13 @@ ASALocalRun/
 *.rpm
 .venv/
 .env
-install/slurm-pkg*
+slurm/install/slurm-pkg*
 blobs
 **/libs
 **/*.mypy_cache/
 **/dist
 **/*egg-info
 **/creds.json
-slurm/install/slurm-pkgs/*
+slurm/install/*.zip
 install/docker/sched
 .DS_Store

--- a/project.ini
+++ b/project.ini
@@ -23,8 +23,8 @@ Description = Version of Slurm to install on the cluster
 ParameterType = StringList
 Config.Plugin = pico.form.Dropdown
 Config.FreeForm = true
-Config.Entries := {[Value="22.05.9-1"], [Value="23.02.5-1"]}
-DefaultValue = 22.05.9-1
+Config.Entries := {[Value="22.05.10-1"], [Value="23.02.6-1"]}
+DefaultValue = 22.05.10-1
 
 [config slurm.shutdown_policy]
 Label = ShutdownPolicy

--- a/slurm/install/rhel.sh
+++ b/slurm/install/rhel.sh
@@ -16,15 +16,17 @@ yum -y install epel-release
 yum -y install munge
 if [ "$OS_VERSION" -gt "7" ]; then
     dnf -y --enablerepo=powertools install -y perl-Switch
+    PACKAGE_DIR=slurm-pkgs-rhel8
 else
     yum -y install python3
+    PACKAGE_DIR=slurm-pkgs-centos7
 fi
 
 
 if [ ${SLURM_ROLE} == "scheduler" ]; then
-    yum  -y install $(ls slurm-pkgs/*${SLURM_VERSION}.el${OS_VERSION}*.rpm)
+    yum  -y install $(ls $PACKAGE_DIR/*${SLURM_VERSION}.el${OS_VERSION}*.rpm)
 else
-    yum  -y install $(ls slurm-pkgs/*${SLURM_VERSION}.el${OS_VERSION}*.rpm | grep -v slurmdbd)
+    yum  -y install $(ls $PACKAGE_DIR/*${SLURM_VERSION}.el${OS_VERSION}*.rpm | grep -v -e slurmdbd -e slurmctld)
 fi
 
 touch $INSALLED_FILE

--- a/slurm/install/slurm_supported_version.py
+++ b/slurm/install/slurm_supported_version.py
@@ -5,19 +5,29 @@ import os
 
 
 SUPPORTED_VERSIONS = {
-    "22.05.9": {
-        "rhel": [{"platform_version": "el8", "arch": "x86_64"},
-                 {"platform_version": "el7", "arch": "x86_64"}],
-        "debian": [{"arch": "amd64"}],
+    "22.05.10": {
+        "rhel": {
+            "rhel8": {"platform_version": "el8", "arch": "x86_64"},
+            "centos7": {"platform_version": "el7", "arch": "x86_64"}
+        },
+        "debian": {
+            "ubuntu20": {"arch": "amd64"},
+            "ubuntu22": {"arch": "amd64"}
+        }
     },
-    "23.02.5": {
-        "rhel": [{"platform_version": "el8", "arch": "x86_64"},
-                 {"platform_version": "el7", "arch": "x86_64"}],
-        "debian": [{"arch": "amd64"}],
+    "23.02.6": {
+        "rhel": {
+            "rhel8": {"platform_version": "el8", "arch": "x86_64"},
+            "centos7": {"platform_version": "el7", "arch": "x86_64"}
+        },
+        "debian": {
+            "ubuntu20": {"arch": "amd64"},
+            "ubuntu22": {"arch": "amd64"}
+        }
     }
 }
 
-CURRENT_DOWNLOAD_URL = "https://github.com/Azure/cyclecloud-slurm/releases/download/2023-09-14-bins"
+CURRENT_DOWNLOAD_URL = "https://github.com/Azure/cyclecloud-slurm/releases/download/2023-10-27-bins"
 
 
 def get_required_packages() -> Dict[str, List[str]]:
@@ -41,10 +51,10 @@ def get_required_packages() -> Dict[str, List[str]]:
         SUPPORTED_VERSIONS.keys()
     ), f"Expected {referenced_versions} == {set(SUPPORTED_VERSIONS.keys())}"
 
-    ret = {}
-    for slurm_version, distros in SUPPORTED_VERSIONS.items():
-        ret[slurm_version] = required_bins = []
-        for debian_version in distros["debian"]:
+    ret = []
+    for slurm_version,ostype in SUPPORTED_VERSIONS.items():
+
+        for distro,pkg in ostype["debian"].items():
             for slurmpkg in [
                 "slurm",
                 "slurm-devel",
@@ -54,12 +64,16 @@ def get_required_packages() -> Dict[str, List[str]]:
                 "slurm-slurmctld",
                 "slurm-slurmdbd",
                 "slurm-slurmd",
-                "slurm-slurmrestd"
+                "slurm-slurmrestd",
+                "slurm-contribs",
+                "slurm-pam-slurm",
+                "slurm-torque",
+                "slurm-openlava",
             ]:
-                required_bins.append(
-                    f"{slurmpkg}_{slurm_version}-1_{debian_version['arch']}.deb"
+                ret.append(
+                    f"{distro}/{slurmpkg}_{slurm_version}-1_{pkg['arch']}.deb"
                 )
-        for rhel_version in distros["rhel"]:
+        for distro,pkg in ostype["rhel"].items():
 
             for slurmpkg in [
                 "slurm",
@@ -72,10 +86,12 @@ def get_required_packages() -> Dict[str, List[str]]:
                 "slurm-perlapi",
                 "slurm-torque",
                 "slurm-openlava",
-                "slurm-slurmrestd"
+                "slurm-slurmrestd",
+                "slurm-pam_slurm",
+                "slurm-contribs"
             ]:
-                required_bins.append(
-                    f"{slurmpkg}-{slurm_version}-1.{rhel_version['platform_version']}.{rhel_version['arch']}.rpm"
+                ret.append(
+                    f"{distro}/{slurmpkg}-{slurm_version}-1.{pkg['platform_version']}.{pkg['arch']}.rpm"
                 )
     return ret
 

--- a/slurm/install/ubuntu.sh
+++ b/slurm/install/ubuntu.sh
@@ -44,11 +44,17 @@ else
     ln -sf /lib/x86_64-linux-gnu/libtinfo.so.5 /usr/lib/x86_64-linux-gnu/libtinfo.so.5
 fi
 
-dpkg -i --force-all $(ls slurm-pkgs/*${SLURM_VERSION}*.deb | grep -v slurmdbd)
+if [ $UBUNTU_VERSION == 22.04 ]; then
+    PACKAGE_DIR=slurm-pkgs-ubuntu22
+else
+    PACKAGE_DIR=slurm-pkgs-ubuntu20
+
+
+dpkg -i --force-all $(ls $PACKAGE_DIR/*${SLURM_VERSION}*.deb | grep -v -e slurmdbd -e slurmctld)
+
 if [ ${SLURM_ROLE} == "scheduler" ]; then
-    # slurmdbd transpilation from rpm to deb fails due to a clashing build uuid
-    # e.g. /usr/lib/.build-id/XX/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    dpkg -i --force-all slurm-pkgs/*slurmdbd*${SLURM_VERSION}*.deb
+    dpkg -i --force-all $PACKAGE_DIR/slurm-slurmctld_${SLURM_VERSION}*.deb
+    dpkg -i --force-all $PACKAGE_DIR/slurm-slurmdbd_${SLURM_VERSION}*.deb
 fi
 
 touch $INSALLED_FILE

--- a/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/slurm/attributes/default.rb
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-default[:slurm][:version] = "22.05.9-1"
+default[:slurm][:version] = "22.05.10-1"
 default[:slurm][:autoscale_version] = "3.0.4"
 default[:slurm][:user][:name] = 'slurm'
 default[:slurm][:cyclecloud_api] = "cyclecloud_api-8.4.1-py2.py3-none-any.whl"

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -513,8 +513,8 @@ Order = 20
         ParameterType = StringList
         Config.Plugin = pico.form.Dropdown
         Config.FreeForm = true
-        Config.Entries := {[Value="22.05.9-1"], [Value="23.02.5-1"]}
-        DefaultValue = 22.05.9-1
+        Config.Entries := {[Value="22.05.10-1"], [Value="23.02.6-1"]}
+        DefaultValue = 22.05.10-1
 
         [[[parameter configuration_slurm_accounting_enabled]]]
         Label = Job Accounting

--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -1,4 +1,4 @@
 FROM almalinux:8.5
 
-RUN yum install -y python36 wget git
+RUN yum install -y python36 wget git unzip
 


### PR DESCRIPTION
- Use updated artifacts.
- Fix our packaging scripts to make use of the updated artifacts and group all artifacts by distros. 
- Adds ubuntu22 to supported images