### PR TITLE
No longer assume AzureCA.pem is required for job accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ yum install -y mariadb-server
 systemctl enable mariadb.service
 systemctl start mariadb.service
 ```
+
+#### AzureCA.pem and existing MariaDB/MySQL instances
+In previous versions, we shipped with an embedded certificate to connect to Azure MariaDB and Azure MySQL instances. This is no longer required. However, if you wish to restore this behavior, select the 'AzureCA.pem' option from the dropdown for the _'Accounting Certificate URL'_ parameter in your your cluster settings.
+
 ### Cost Reporting
 
 `azslurm` in slurm 3.0 project now comes with a new experimental feature `azslurm cost` to display costs of slurm jobs. This requires Cyclecloud 8.4 or newer, as well

--- a/install.sh
+++ b/install.sh
@@ -101,12 +101,15 @@ items = [x.split(':', 1) for x in sys.stdin.read().split(';')];\
 tags = dict([tuple([i[0].lower(), i[-1]]) for i in items]);\
 print(tags.get('clusterid', 'unknown'))")
 
-config_dir="/sched/$(jetpack config cyclecloud.cluster.name)"
+cluster_name=$(jetpack config cyclecloud.cluster.name)
+escaped_cluster_name=$(python3 -c "import re; print(re.sub('[^a-zA-Z0-9-]', '-', '$cluster_name').lower())")
+
+config_dir=/sched/$escaped_cluster_name
 azslurm initconfig --username $(jetpack config cyclecloud.config.username) \
                    --password $(jetpack config cyclecloud.config.password) \
                    --url      $(jetpack config cyclecloud.config.web_server) \
                    --cluster-name "$(jetpack config cyclecloud.cluster.name)" \
-                   --config-dir "$config_dir" \
+                   --config-dir $config_dir \
                    --accounting-tag-name ClusterId \
                    --accounting-tag-value "$tag" \
                    --accounting-subscription-id $(jetpack config azure.metadata.compute.subscriptionId) \
@@ -114,6 +117,6 @@ azslurm initconfig --username $(jetpack config cyclecloud.config.username) \
                    > $INSTALL_DIR/autoscale.json
 
 
-azslurm partitions > "$config_dir"/azure.conf
+azslurm partitions > $config_dir/azure.conf
 
 chown slurm:slurm $VENV/../logs/*.log

--- a/slurm/install/templates/slurm.conf.template
+++ b/slurm/install/templates/slurm.conf.template
@@ -13,6 +13,10 @@ SchedulerType=sched/backfill
 SelectType=select/cons_tres
 GresTypes=gpu
 SelectTypeParameters=CR_Core_Memory
+# We use a "safe" form of the CycleCloud ClusterName throughout slurm.
+# First we lowercase the cluster name, then replace anything
+# that is not letters, digits and '-' with a '-'
+# eg My Cluster == my-cluster
 ClusterName={cluster_name}
 JobAcctGatherType=jobacct_gather/none
 SlurmctldDebug=debug

--- a/slurm/install/templates/slurmdbd.conf.template
+++ b/slurm/install/templates/slurmdbd.conf.template
@@ -32,4 +32,4 @@ StorageType=accounting_storage/mysql
 StorageHost={accountdb}
 {storagepass}
 StorageUser={dbuser}
-StorageParameters=SSL_CA=/etc/slurm/AzureCA.pem
+{storage_parameters}

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -566,9 +566,13 @@ Order = 20
 
         [[[parameter configuration_slurm_accounting_certificate_url]]]
         Label = SSL Certificate URL
-        Description = URL to fetch SSL certificate for authentication to DB
+        Description = URL to fetch SSL certificate for authentication to DB. Use AzureCA.pem (embedded) for use with deprecated MariaDB instances.
         Conditions.Excluded := configuration_slurm_accounting_enabled isnt true
-        ParameterType = String
+        ParameterType = StringList
+        Config.Plugin = pico.form.Dropdown
+        Config.FreeForm = true
+        Config.Entries := {[Value=""], [Value="AzureCA.pem"]}
+        DefaultValue = ""
 
         [[[parameter configuration_slurm_shutdown_policy]]]
 	Label = Shutdown Policy


### PR DESCRIPTION
In order to work with Azure MariaDB instances, we had to explicitly add a certificate authority in the StorageParameters. This is no longer needed. This PR still leaves this as an option, by converting Accounting Certificate URL to an editable dropdown with AzureCA.pem as an option.