### PR TITLE
Allow local override of GPUs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,6 +113,7 @@ azslurm initconfig --username $(jetpack config cyclecloud.config.username) \
                    --accounting-tag-name ClusterId \
                    --accounting-tag-value "$tag" \
                    --accounting-subscription-id $(jetpack config azure.metadata.compute.subscriptionId) \
+                   --default-resource '{"select": {}, "name": "slurm_gpus", "value": "node.gpu_count"}' \
                    --cost-cache-root $INSTALL_DIR/.cache \
                    > $INSTALL_DIR/autoscale.json
 

--- a/slurm/src/slurmcc/partition.py
+++ b/slurm/src/slurmcc/partition.py
@@ -161,6 +161,8 @@ class Partition:
 
     @property
     def gpu_count(self) -> int:
+        if "slurm_gpus" in self.buckets[0].resources:
+            return self.buckets[0].resources["slurm_gpus"]
         return self.buckets[0].gpu_count
 
 


### PR DESCRIPTION
Per README.md additions: 
For some regions and VM sizes, some subscriptions may report an incorrect number of GPUs. This value is controlled in `/opt/azure/slurm/autoscale.json`

The default definition looks like the following: 
```json
  "default_resources": [
    {
      "select": {},
      "name": "slurm_gpus",
      "value": "node.gpu_count"
    }
  ],
```
Note that here it is saying "For all VM sizes in all nodearrays, create a resource called `slurm_gpus` with the value of the `gpu_count` CycleCloud is reporting".

A common solution is to add a specific override for that VM size. In this case, `8` GPUs. Note the ordering here is critical - the blank `select` statement will set the default for all possible VM sizes and all other definitions will be ignored. For more information on how scalelib `default_resources` work, the underlying library used in all CycleCloud autoscalers, [see the ScaleLib documentation](https://github.com/Azure/cyclecloud-scalelib?tab=readme-ov-file#resources)

```json
  "default_resources": [
    {
      "select": {"node.vm_size": "Standard_XYZ"},
      "name": "slurm_gpus",
      "value": 8
    },
    {
      "select": {},
      "name": "slurm_gpus",
      "value": "node.gpu_count"
    }
  ],
```

Simply run `azslurm scale` again for the changes to take effect. Note that if you need to iterate on this, you may also run `azslurm partitions`, which will write the partition definition out to stdout. This output will match what is in `/etc/slurm/azure.conf` after `azslurm scale` is run.
Fixes: #198