### PR TITLE
Add PMC repositories as sources for slurm binaries.

### DIFF
--- a/slurm/install/install.py
+++ b/slurm/install/install.py
@@ -61,6 +61,7 @@ class InstallSettings:
         self.acct_pass: Optional[str] = config["slurm"]["accounting"].get("password")
         self.acct_url: Optional[str] = config["slurm"]["accounting"].get("url")
         self.acct_cert_url: Optional[str] = config["slurm"]["accounting"].get("certificate_url")
+        self.disable_pmc = config["slurm"].get("disable_pmc") or False
 
         self.use_nodename_as_hostname = config["slurm"].get(
             "use_nodename_as_hostname", False
@@ -142,7 +143,7 @@ def setup_users(s: InstallSettings) -> None:
 
 
 def run_installer(s: InstallSettings, path: str, mode: str) -> None:
-    subprocess.check_call([path, mode, s.slurmver])
+    subprocess.check_call([path, mode, s.slurmver, str(s.disable_pmc)])
 
 
 def fix_permissions(s: InstallSettings) -> None:

--- a/slurm/install/package.py
+++ b/slurm/install/package.py
@@ -89,6 +89,8 @@ def execute() -> None:
     _add("install_logging.conf", "conf/install_logging.conf")
     _add("installlib.py", "installlib.py")
     _add("install.py", "install.py")
+    _add("slurmel8.repo", "slurmel8.repo")
+    _add("slurmel7.repo", "slurmel7.repo")
     _add("ubuntu.sh", "ubuntu.sh", 600)
     _add("rhel.sh", "rhel.sh", 600)
     _add("AzureCA.pem", "AzureCA.pem")

--- a/slurm/install/rhel.sh
+++ b/slurm/install/rhel.sh
@@ -10,6 +10,7 @@ fi
 
 SLURM_ROLE=$1
 SLURM_VERSION=$2
+DISABLE_PMC=$3
 OS_VERSION=$(cat /etc/os-release  | grep VERSION_ID | cut -d= -f2 | cut -d\" -f2 | cut -d. -f1)
 
 yum -y install epel-release
@@ -22,11 +23,60 @@ else
     PACKAGE_DIR=slurm-pkgs-centos7
 fi
 
+slurm_packages="slurm slurm-slurmrestd slurm-libpmi slurm-devel slurm-pam_slurm slurm-perlapi slurm-torque slurm-openlava slurm-example-configs"
+sched_packages="slurm-slurmctld slurm-slurmdbd"
+execute_packages="slurm-slurmd"
+
+
+if [ "$DISABLE_PMC" == "False" ]; then
+
+    if [ "$OS_VERSION" -gt "7" ]; then
+        cp slurmel8.repo /etc/yum.repos.d/slurm.repo
+    else
+        cp slurmel7.repo /etc/yum.repos.d/slurm.repo
+    fi
+
+    ## This package is pre-installed in all hpc images used by cyclecloud, but if customer wants to
+    ## build an image from generic marketplace images then this package sets up the right gpg keys for PMC.
+    if [ ! -e /etc/yum.repos.d/microsoft-prod.repo ];then
+        curl -sSL -O https://packages.microsoft.com/config/rhel/$OS_VERSION/packages-microsoft-prod.rpm
+        rpm -i packages-microsoft-prod.rpm
+        rm packages-microsoft-prod.rpm
+    fi
+    for pkg in $slurm_packages; do
+        yum -y install $pkg-${SLURM_VERSION}.el${OS_VERSION} --disableexcludes slurm
+    done
+    if [ ${SLURM_ROLE} == "scheduler" ]; then
+        for pkg in $sched_packages; do
+            yum -y install $pkg-${SLURM_VERSION}.el${OS_VERSION} --disableexcludes slurm
+        done
+    fi
+
+    if [ ${SLURM_ROLE} == "execute" ]; then
+        for pkg in $execute_packages; do
+            yum -y install $pkg-${SLURM_VERSION}.el${OS_VERSION} --disableexcludes slurm
+        done
+    fi
+    touch $INSALLED_FILE
+
+    exit
+fi
+
+
+for pkg in $slurm_packages; do
+    yum -y install $(ls $PACKAGE_DIR/$pkg-${SLURM_VERSION}.el${OS_VERSION}*.rpm)
+done
 
 if [ ${SLURM_ROLE} == "scheduler" ]; then
-    yum  -y install $(ls $PACKAGE_DIR/*${SLURM_VERSION}.el${OS_VERSION}*.rpm)
-else
-    yum  -y install $(ls $PACKAGE_DIR/*${SLURM_VERSION}.el${OS_VERSION}*.rpm | grep -v -e slurmdbd -e slurmctld)
+    for pkg in $sched_packages; do
+        yum  -y install $(ls $PACKAGE_DIR/$pkg-${SLURM_VERSION}.el${OS_VERSION}*.rpm)
+    done
+fi
+
+if [ ${SLURM_ROLE} == "execute" ]; then
+    for pkg in $execute_packages; do
+        yum  -y install $(ls $PACKAGE_DIR/$pkg-${SLURM_VERSION}.el${OS_VERSION}*.rpm)
+    done
 fi
 
 touch $INSALLED_FILE

--- a/slurm/install/slurmel7.repo
+++ b/slurm/install/slurmel7.repo
@@ -1,0 +1,7 @@
+[slurm]
+name=Slurm Workload Manager
+baseurl=https://packages.microsoft.com/yumrepos/slurm-el7-insiders
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+priority=10

--- a/slurm/install/slurmel8.repo
+++ b/slurm/install/slurmel8.repo
@@ -1,0 +1,7 @@
+[slurm]
+name=Slurm Workload Manager
+baseurl=https://packages.microsoft.com/yumrepos/slurm-el8-insiders
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+priority=10

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -35,7 +35,8 @@ Autoscale = $Autoscale
         slurm.additional.config = $additional_slurm_config
         slurm.ha_enabled = $configuration_slurm_ha_enabled
         slurm.launch_parameters = $configuration_slurm_launch_parameters
-        
+        slurm.disable_pmc = $configuration_slurm_disable_pmc
+
         # Disable ip-XXXXXXXX hostname generation
         cyclecloud.hosts.standalone_dns.enabled = ${NodeNameIsHostname==false}
         cyclecloud.hosts.simple_vpc_dns.enabled = ${NodeNameIsHostname==false}
@@ -680,6 +681,12 @@ Order = 20
         DefaultValue = =undefined
         Description = Cluster init specs to apply to Dynamic execute nodes
         ParameterType = Cloud.ClusterInitSpecs
+
+        [[[parameter configuration_slurm_disable_pmc]]]
+        Label = Disable PMC
+        Description = Disable packages from packages.microsoft.com
+        ParameterType = Boolean
+        DefaultValue = false
 	
 
     [[parameters Advanced Networking]]


### PR DESCRIPTION
This commit adds packages.microsoft.com repositories as source for slurm rpms and debs. Packages are fetched during installation. There is also an option added to disable fetching packages from PMC and complete the installation in the traditional way.