### PR TITLE
Use latest version of scalelib - 1.0.2

### DIFF
--- a/package.py
+++ b/package.py
@@ -11,7 +11,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-SCALELIB_VERSION = "1.0.1"
+SCALELIB_VERSION = "1.0.2"
 CYCLECLOUD_API_VERSION = "8.4.1"
 
 


### PR DESCRIPTION
Use the latest version of scalelib, including the latest embedded VM Size information for certain locked down environments.