### PR TITLE
slurm.dampen_memory was ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ A common solution is to add a specific override for that VM size. In this case, 
 
 Simply run `azslurm scale` again for the changes to take effect. Note that if you need to iterate on this, you may also run `azslurm partitions`, which will write the partition definition out to stdout. This output will match what is in `/etc/slurm/azure.conf` after `azslurm scale` is run.
 
+### Dampening Memory
+
+Slurm requires that you define the amount of free memory, after OS/Applications are considered, when reporting memory as a resource. If the reported memory is too low, then Slurm will reject this node. To overcome this, by default we dampen the memory by 5% or 1g, whichever is larger.
+
+To change this dampening, there are two options.
+1) You can define `slurm.dampen_memory=X` where X is an integer percentage (5 == 5%)
+2) Create a default_resource definition in the /opt/azurehpc/slurm/autoscale.json file. 
+  ```json
+    "default_resources": [
+    {
+      "select": {},
+      "name": "slurm_memory",
+      "value": "node.memory"
+    }
+  ],
+  ```
+
+  Default resources are a powerful tool that the underlying library ScaleLib provides. [see the ScaleLib documentation](https://github.com/Azure/cyclecloud-scalelib?tab=readme-ov-file#resources)
+
+  **Note:** `slurm.dampen_memory` takes precedence, so the default_resource `slurm_memory` will be ignored if `slurm.dampen_memory` is defined.
+
 
 ### Transitioning from 2.7 to 3.0
 

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -623,6 +623,19 @@ def _partitions(
 
     written_dynamic_partitions = set()
 
+    writer.write(
+        f"# Note: To account for OS/VM overhead, by default we reduce the reported memory from CycleCloud by 5%.\n"
+    )
+    writer.write(
+        "# We do this because Slurm will reject a node that reports less than what is defined in this config.\n"
+    )
+    writer.write(
+        "# There are two ways to change this:\n" +
+        "#  1) edit slurm.dampen_memory=X in the nodearray's Configuration where X is percentage (5 = 5%).\n"
+        "#  2) Edit the slurm_memory value defined in /opt/azurehpc/slurm/autosacle.json.\n" + 
+        "# Note that slurm.dampen_memory will take precedence.\n"
+    )
+
     for partition in partitions:
         if partition.dynamic_config:
             if partition.name in written_dynamic_partitions:
@@ -648,21 +661,7 @@ def _partitions(
             threads = 1
         def_mem_per_cpu = memory // cpus
 
-        writer.write(
-            "# Note: CycleCloud reported a RealMemory of %d but we reduced it by %d (i.e. max(1gb, %d%%)) to account for OS/VM overhead which\n"
-            % (
-                int(partition.memory * 1024),
-                -1,
-                -1,
-                # int(partition.dampen_memory * 100),
-            )
-        )
-        writer.write(
-            "# would result in the nodes being rejected by Slurm if they report a number less than defined here.\n"
-        )
-        writer.write(
-            "# To pick a different percentage to dampen, set slurm.dampen_memory=X in the nodearray's Configuration where X is percentage (5 = 5%).\n"
-        )
+
         writer.write(
             "PartitionName={} Nodes={} Default={} DefMemPerCPU={} MaxTime=INFINITE State=UP\n".format(
                 partition.name, partition.node_list, default_yn, def_mem_per_cpu

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -85,7 +85,9 @@ def to_hostlist(nodes: Union[str, List[str]]) -> str:
         nodes_str = ",".join(nodes)
     else:
         nodes_str = nodes
-
+    # prevent poor sorting of nodes and getting node lists like htc-1,htc-10-19, htc-2, htc-20-29 etc
+    sorted_nodes = sorted(nodes_str.split(","), key=get_sort_key_func(is_hpc=False))
+    nodes_str = ",".join(sorted_nodes)
     return scontrol(["show", "hostlist", nodes_str])
 
 

--- a/slurm/test/slurmcc_test/testutil.py
+++ b/slurm/test/slurmcc_test/testutil.py
@@ -43,7 +43,10 @@ def _show_hostlist(node_list: List[str]) -> str:
     for prefix, names in by_prefix.items():
         nums = []
         for name in names:
-            nums.append(int(name.split("-")[-1]))
+            try:
+                nums.append(int(name.split("-")[-1]))
+            except ValueError:
+                raise RuntimeError(f"Bad name - {name} from list {node_list}")
         nums = sorted(nums)
         min_num = nums[0]
         last_num = min_num
@@ -52,7 +55,6 @@ def _show_hostlist(node_list: List[str]) -> str:
             if num > last_num + 1 or n == len(nums) - 2:
                 if n == len(nums) - 2:
                     last_num = num
-                print(f"n={n} min_num={min_num} last_num={last_num}")
                 ret.append(f"{prefix}-[{min_num}-{last_num}]")
                 last_num = min_num = num
             else:
@@ -68,6 +70,10 @@ class MockNativeSlurmCLI(NativeSlurmCLI):
         if args[0:2] == ["show", "hostnames"]:
             assert len(args) == 3
             return "\n".join(_show_hostnames(args[-1]))
+        
+        if args[0:2] == ["show", "hostlist"]:
+            assert len(args) == 3
+            return _show_hostlist(args[-1].split(","))
 
         if args[0:2] == ["show", "nodes"]:
             assert len(args) == 3


### PR DESCRIPTION
Fixes: #30

Related new documentation:

Slurm requires that you define the amount of free memory, after OS/Applications are considered, when reporting memory as a resource. If the reported memory is too low, then Slurm will reject this node. To overcome this, by default we dampen the memory by 5% or 1g, whichever is larger.

To change this dampening, there are two options.
1) You can define `slurm.dampen_memory=X` where X is an integer percentage (5 == 5%)
2) Crate a default_resource definition in the /opt/azurehpc/slurm/autoscale.json file. 
  ```json
    "default_resources": [
    {
      "select": {},
      "name": "slurm_memory",
      "value": "node.memory"
    }
  ],
  ```
  Default resources are a powerful tool that the underlying library ScaleLib provides. [see the ScaleLib documentation](https://github.com/Azure/cyclecloud-scalelib?tab=readme-ov-file#resources)