### PR TITLE
Make scontrol update command always return true.

### DIFF
--- a/sbin/prolog.sh
+++ b/sbin/prolog.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -x
+set +e
 
 log=/var/log/slurmctld/prolog_slurmctld.log
 script=/opt/azurehpc/slurm/get_acct_info.sh
@@ -37,3 +38,5 @@ if [ $ret -eq 0 ]; then
 else
 	$scontrol update job=$job admincomment="$output"
 fi
+
+exit 0


### PR DESCRIPTION
For certain cron jobs in slurm, running scontrol update command is blocked by slurm. This allows the user to cron jobs via scrontab. The downside is that the admin comment field won't be populated for these jobs.