### PR TITLE
Update rhel.sh

### DIFF
--- a/slurm/install/rhel.sh
+++ b/slurm/install/rhel.sh
@@ -12,17 +12,35 @@ SLURM_ROLE=$1
 SLURM_VERSION=$2
 DISABLE_PMC=$3
 OS_VERSION=$(cat /etc/os-release  | grep VERSION_ID | cut -d= -f2 | cut -d\" -f2 | cut -d. -f1)
+OS_NAME=$(/etc/os-release|grep "ID"|head -1| cut -d= -f2 | cut -d\" -f2)
 
-yum -y install epel-release
-yum -y install munge
-if [ "$OS_VERSION" -gt "7" ]; then
+
+
+case "$OS_VERSION" in
+8)
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    dnf install munge
     dnf -y --enablerepo=powertools install -y perl-Switch
     PACKAGE_DIR=slurm-pkgs-rhel8
-else
+    ;;
+9)
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    dnf install munge
+    # defaulting to alma 9 and rocky
+    if ["$OS_NAME" -eq "rhel"]; then
+        dnf install -y perl-Switch
+    else
+        dnf -y --enablerepo=crb install -y perl-Switch
+    fi
+    PACKAGE_DIR=slurm-pkgs-rhel9
+    ;;
+*)
+    yum -y install epel-release
+    yum -y install munge
     yum -y install python3
     PACKAGE_DIR=slurm-pkgs-centos7
-fi
-
+    ;;
+esac
 slurm_packages="slurm slurm-slurmrestd slurm-libpmi slurm-devel slurm-pam_slurm slurm-perlapi slurm-torque slurm-openlava slurm-example-configs"
 sched_packages="slurm-slurmctld slurm-slurmdbd"
 execute_packages="slurm-slurmd"
@@ -30,11 +48,17 @@ execute_packages="slurm-slurmd"
 
 if [ "$DISABLE_PMC" == "False" ]; then
 
-    if [ "$OS_VERSION" -gt "7" ]; then
+    case "$OS_VERSION" in
+    8)
         cp slurmel8.repo /etc/yum.repos.d/slurm.repo
-    else
+        ;;
+    9)
+        cp slurmel9.repo /etc/yum.repos.d/slurm.repo
+        ;;
+    *)
         cp slurmel7.repo /etc/yum.repos.d/slurm.repo
-    fi
+        ;;
+    esac
 
     ## This package is pre-installed in all hpc images used by cyclecloud, but if customer wants to
     ## build an image from generic marketplace images then this package sets up the right gpg keys for PMC.


### PR DESCRIPTION
adding support for rhel9

I did not fully test this as I do not have rhel9 packages, the repositories and checks will enable redhat 9 and almalinux 9 (should work with rocky).

