### PR TITLE
Fix manual suspend and avoid KeepAlive=true resume/resume_fail loop via new azslurm return_to_idle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,21 @@ To change this dampening, there are two options.
   **Note:** `slurm.dampen_memory` takes precedence, so the default_resource `slurm_memory` will be ignored if `slurm.dampen_memory` is defined.
 
 
+### KeepAlive set in CycleCloud and Zombie nodes
+If you choose to set KeepAlive=true in CycleCloud, then Slurm will still change its internal power state to `powered_down`. At this point, that node is now a `zombie` node. A `zombie` node is one where it exists in CycleCloud but is in a powered_down state in Slurm.
+
+Previous to 3.0.7, Slurm would try and fail to resume `zombie` nodes over and over again. As of 3.0.7, the `zombie` node will be left in a `down~` (or `drained~`). If you want the `zombie` node to rejoin the cluster, g=you must log into it and restart the `slurmd`, typically via `systemctl restart slurmd`. If you want these nodes to be terminated, you can either manually terminate them via the UI or `azslurm suspend`, or to do this automatically, you can add the following to the autoscale.json file found at `/opt/azurehpc/slurm/autoscale.json`
+
+This will change the behavior of the `azslurm return_to_idle` command that is, by default, run as a cronjob every 5 minutes. You can also execute it manually, with the argument `--terminate-zombie-nodes`.
+
+```json
+{
+  "return-to-idle": {
+    "terminate-zombie-nodes": true
+  }
+}
+```
+
 ### Transitioning from 2.7 to 3.0
 
 1. The installation folder changed

--- a/package.py
+++ b/package.py
@@ -157,6 +157,7 @@ def execute() -> None:
     _add("sbin/prolog.sh", "sbin/prolog.sh")
     _add("sbin/resume_program.sh", "sbin/resume_program.sh")
     _add("sbin/return_to_idle.sh", "sbin/return_to_idle.sh")
+    _add("sbin/return_to_idle_legacyfin.sh", "sbin/return_to_idle_legacy.sh")
     _add("sbin/suspend_program.sh", "sbin/suspend_program.sh")
     _add("sbin/get_acct_info.sh", "sbin/get_acct_info.sh")
     _add("logging.conf", "slurm/conf/logging.conf")

--- a/sbin/return_to_idle.sh
+++ b/sbin/return_to_idle.sh
@@ -1,23 +1,4 @@
 #!/bin/bash
 
-down_and_off=$(sinfo -O nodelist:500,statelong -h | grep down~ | cut -d" " -f1)
-
-if [ "$down_and_off" != "" ]; then
-  echo $(date): Setting the following down~ nodes to idle~: $down_and_off
-  scontrol update nodename=$down_and_off state=idle
-  if [ $? != 0 ]; then
-    echo $(date): Updating nodes failed! Command was "scontrol update nodename=$down_and_off state=idle"
-    exit 1
-  fi
-fi
-
-drained_and_off=$(sinfo -O nodelist:500,statelong -h | grep drained~ | cut -d" " -f1)
-
-if [ "$drained_and_off" != "" ]; then
-  echo $(date): Setting the following drained~ nodes to idle~: $drained_and_off
-  scontrol update nodename=$drained_and_off state=idle
-  if [ $? != 0 ]; then
-    echo $(date): Updating nodes failed! Command was "scontrol update nodename=$drained_and_off state=idle"
-    exit 1
-  fi
-fi
+source /opt/azurehpc/slurm/venv/bin/activate
+azslurm return_to_idle

--- a/sbin/return_to_idle_legacy.sh
+++ b/sbin/return_to_idle_legacy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+down_and_off=$(sinfo -O nodelist:500,statelong -h | grep down~ | cut -d" " -f1)
+
+if [ "$down_and_off" != "" ]; then
+  echo $(date): Setting the following down~ nodes to idle~: $down_and_off
+  scontrol update nodename=$down_and_off state=idle
+  if [ $? != 0 ]; then
+    echo $(date): Updating nodes failed! Command was "scontrol update nodename=$down_and_off state=idle"
+    exit 1
+  fi
+fi
+
+drained_and_off=$(sinfo -O nodelist:500,statelong -h | grep drained~ | cut -d" " -f1)
+
+if [ "$drained_and_off" != "" ]; then
+  echo $(date): Setting the following drained~ nodes to idle~: $drained_and_off
+  scontrol update nodename=$drained_and_off state=idle
+  if [ $? != 0 ]; then
+    echo $(date): Updating nodes failed! Command was "scontrol update nodename=$drained_and_off state=idle"
+    exit 1
+  fi
+fi

--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -323,6 +323,110 @@ class SlurmCLI(CommonCLI):
         node_mgr = self._node_mgr(config, self._driver(config))
         self._shutdown(config, node_list=node_list, node_mgr=node_mgr)
 
+    def return_to_idle_parser(self, parser: ArgumentParser) -> None:
+        parser.set_defaults(read_only=False)
+        parser.add_argument("--terminate-zombie-nodes", action="store_true", default=False)
+
+    def return_to_idle(
+        self, config: Dict, terminate_zombie_nodes: bool = False
+    ) -> None:
+        """
+        Nodes that fail to resume in ResumeTimeout seconds will be left
+        in a down~ state - i.e. down and powered_down. It is also possible
+        the nodes will be in a drained~ state, if the node was drained during
+        resume. This command will set those nodes to idle~.
+
+        The one exception is for nodes that have KeepAlive set in CycleCloud.
+        Those nodes will be left as down~ and will be logged. When the user
+        unclicks the KeepAlive, the node can be automatically shutdown if --terminate-zombie-nodes
+        is set, or config["return-to-idle"]["terminate-zombie-nodes"] is true.
+        """
+        if not slutil.is_autoscale_enabled():
+            return
+
+        # this is always run as root, so bump up the loglevel to info
+        stream_handlers = [
+            x
+            for x in logging.getLogger().handlers
+            if isinstance(x, logging.StreamHandler)
+        ]
+        for sh in stream_handlers:
+            sh.setLevel(logging.INFO)
+
+        node_mgr = self._node_mgr(config)
+        ccnodes = node_mgr.get_nodes()
+        ccnodes_by_name = hpcutil.partition_single(ccnodes, lambda node: node.name)
+
+        snodes = slutil.show_nodes()
+        if terminate_zombie_nodes:
+            if "return_to_idle" not in config:
+                config["return-to-idle"] = {}
+            config["return-to-idle"]["terminate-zombie-nodes"] = True
+            
+        SlurmCLI._return_to_idle(config, snodes, ccnodes_by_name, scontrol, node_mgr)
+
+    @staticmethod
+    def _return_to_idle(
+        config: Dict,
+        snodes: List[Dict],
+        ccnodes_by_name: Dict[str, Node],
+        scontrol_func: Callable,
+        node_mgr: NodeManager,
+    ) -> None:
+        to_set_to_idle = []
+        to_power_down = []
+
+        for snode in snodes:
+            slurm_states = set(snode["State"].split("+"))
+            # ignore non-cloud nodes, as they aren't our responsibility
+            if "CLOUD" not in slurm_states:
+                continue
+
+            power_down_states = set(["POWERED_DOWN"])
+            if not power_down_states.intersection(slurm_states):
+                continue
+            node_name = snode["NodeName"]
+
+            if "DOWN" in slurm_states or "DRAINED" in slurm_states:
+                # Only nodes that do not exist in CycleCloud can be set to idle~
+                if node_name not in ccnodes_by_name:
+                    to_set_to_idle.append(node_name)
+                    continue
+                
+                # keepalive nodes must be left alone, and obviously cannot be terminated.
+                ccnode = ccnodes_by_name[node_name]
+                if ccnode.keep_alive:
+                    logging.warning(
+                        f"{node_name} exists and has KeepAlive=true in CycleCloud. Cannot set to idle."
+                    )
+                    continue
+                
+                terminate_zombie_nodes = config.get("return-to-idle", {}).get(
+                        "terminate-zombie-nodes", False
+                )
+                
+                if terminate_zombie_nodes:
+                    logging.warning(
+                        f"Found zombie node {node_name}. Will set to power_down because terminate-zombie-nodes is set."
+                    )
+                    # Terminate the node - note that the next round the node will be set to idle.
+                    to_power_down.append(node_name)
+                else:
+                    logging.warning(
+                        f"Node {node_name} is in DOWN~ state but exists in CycleCloud. To terminate the node"
+                        + ", shutdown the node manually (via azslurm suspend or the UI) or, if you want the node"
+                        + " to join the cluster, login to it and restart slurmd."
+                    )
+
+        if to_power_down:
+            to_power_down_idle_str = slutil.to_hostlist(to_power_down, scontrol_func=scontrol_func)
+            slutil.scontrol(["update", f"nodename={to_power_down_idle_str}", "state=power_down"])
+
+        if to_set_to_idle:
+            to_set_to_idle_str = slutil.to_hostlist(to_set_to_idle, scontrol_func=scontrol_func)
+            logging.warning(f"Setting nodes {to_set_to_idle} to idle.")
+            scontrol_func(["update", f"nodename={to_set_to_idle_str}", "state=idle"])
+    
 
     def _get_node_manager(self, config: Dict, force: bool = False) -> NodeManager:
         return self._node_mgr(config, self._driver(config), force=force)

--- a/slurm/src/slurmcc/partition.py
+++ b/slurm/src/slurmcc/partition.py
@@ -150,8 +150,9 @@ class Partition:
                                     node["NodeName"],
                                     self.machine_type)
                         ret.append(node["NodeName"])
-
-            self.__dynamic_node_list_cache = slutil.to_hostlist(ret)
+                        
+            self.__dynamic_node_list_cache = slutil.to_hostlist(ret) if ret else ""
+            
         return self.__dynamic_node_list_cache
     
     def _static_all_nodes(self) -> List[str]:

--- a/slurm/test/slurmcc_test/cli_test.py
+++ b/slurm/test/slurmcc_test/cli_test.py
@@ -1,0 +1,269 @@
+from io import StringIO
+from typing import List, Optional
+
+from hpc.autoscale.hpctypes import Memory
+from hpc.autoscale.node.bucket import NodeBucket, NodeDefinition
+from hpc.autoscale.results import ShutdownResult
+
+from slurmcc import cli, util
+from slurmcc.partition import Partition
+
+from slurmcc_test import testutil
+
+
+class SimpleMockLimits:
+    def __init__(self, max_count: int) -> None:
+        self.max_count = max_count
+
+
+def setup() -> None:
+    util.TEST_MODE = True
+    util.SLURM_CLI = testutil.MockNativeSlurmCLI()
+
+def teardown() -> None:
+    util.TEST_MODE = False
+    util.SLURM_CLI = testutil.MockNativeSlurmCLI()
+
+
+def make_partition(
+    name: str,
+    is_default: bool,
+    is_hpc: bool,
+    use_pcpu: bool = True,
+    slurm_memory: str = "",
+    dampen_memory: Optional[float] = None,
+    dynamic_config: str = "",
+) -> Partition:
+    resources = {"slurm_memory": Memory.value_of(slurm_memory)} if slurm_memory else {}
+    node_def = NodeDefinition(
+        name,
+        f"b-id-{name}",
+        "Standard_F4",
+        "southcentralus",
+        False,
+        "subnet",
+        4,
+        0,
+        Memory.value_of("16g"),
+        f"pg-{name}" if is_hpc else None,
+        resources,
+        {},
+    )
+
+    limits = SimpleMockLimits(100)
+
+    bucket = NodeBucket(node_def, limits, 100, [])
+    return Partition(
+        name,
+        name,
+        f"pre-",
+        "Standard_F4",
+        is_default,
+        is_hpc,
+        100,
+        [bucket],
+        100,
+        use_pcpu,
+        dynamic_config,
+        {},
+        ["Standard_f4"],
+        dampen_memory,
+    )
+
+
+def test_partitions() -> None:
+
+    partitions = [
+        make_partition("htc", False, False),
+        make_partition("hpc", True, True),
+        make_partition("dynamic", False, False, dynamic_config="-Z Feature=dyn"),
+    ]
+
+    # Define neither slurm_memory nor dampen_memory, autoscale=true
+    # Expect full 16g to be applied.
+    writer = StringIO()
+
+    cli._partitions(partitions, writer, autoscale=True)
+    actual = "\n".join(
+        [x for x in writer.getvalue().splitlines() if not x.startswith("#")]
+    )
+    with open("/tmp/partitions.txt", "w") as f:
+        f.write(actual)
+    assert (
+        actual
+        == """PartitionName=htc Nodes=pre-[1-100] Default=NO DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=15360
+PartitionName=hpc Nodes=pre-[1-100] Default=YES DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=15360
+Nodeset=dynamicns Feature=dyn
+PartitionName=dynamic Nodes=dynamicns"""
+    )
+
+    # Define neither slurm_memory nor dampen_memory, autoscale=true
+    # Expect default of 16g - 1gb to be applied.
+    # Exoect state=FUTURE instead of CLOUD
+    writer = StringIO()
+    cli._partitions(partitions, writer, autoscale=False)
+    actual = "\n".join(
+        [x for x in writer.getvalue().splitlines() if not x.startswith("#")]
+    )
+    assert (
+        actual
+        == """PartitionName=htc Nodes=pre-[1-100] Default=NO DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=FUTURE CPUs=4 ThreadsPerCore=1 RealMemory=15360
+PartitionName=hpc Nodes=pre-[1-100] Default=YES DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=FUTURE CPUs=4 ThreadsPerCore=1 RealMemory=15360
+Nodeset=dynamicns Feature=dyn
+PartitionName=dynamic Nodes=dynamicns"""
+    )
+
+    # Define only slurm_memory resource, autoscale=true
+    # Expect slurm_memory (15g, 14g) will be applied.
+    partitions = [
+        make_partition("htc", False, False, slurm_memory="15g"),
+        make_partition("hpc", True, True, slurm_memory="14g"),
+        make_partition(
+            "dynamic", False, False, dynamic_config="-Z Feature=dyn", slurm_memory="13g"
+        ),
+    ]
+    # No slurm.dampen_memory or slurm_memory resource, autoscale=FALSE
+    writer = StringIO()
+    cli._partitions(partitions, writer, autoscale=True)
+    actual = "\n".join(
+        [x for x in writer.getvalue().splitlines() if not x.startswith("#")]
+    )
+    assert (
+        actual
+        == """PartitionName=htc Nodes=pre-[1-100] Default=NO DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=15360
+PartitionName=hpc Nodes=pre-[1-100] Default=YES DefMemPerCPU=3584 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=14336
+Nodeset=dynamicns Feature=dyn
+PartitionName=dynamic Nodes=dynamicns"""
+    )
+
+    # Define both slurm_memory resource and slurm.dampen_memory, autoscale=true
+    # Expect dampen_memory (25%, 50%) will be applied
+    partitions = [
+        make_partition("htc", False, False, slurm_memory="15g", dampen_memory=0.25),
+        make_partition("hpc", True, True, slurm_memory="14g", dampen_memory=0.5),
+        make_partition(
+            "dynamic",
+            False,
+            False,
+            dynamic_config="-Z Feature=dyn",
+            slurm_memory="13g",
+            dampen_memory=0.75,
+        ),
+    ]
+
+    writer = StringIO()
+    cli._partitions(partitions, writer, autoscale=True)
+    actual = "\n".join(
+        [x for x in writer.getvalue().splitlines() if not x.startswith("#")]
+    )
+    assert (
+        actual
+        == """PartitionName=htc Nodes=pre-[1-100] Default=NO DefMemPerCPU=3072 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=12288
+PartitionName=hpc Nodes=pre-[1-100] Default=YES DefMemPerCPU=2048 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=8192
+Nodeset=dynamicns Feature=dyn
+PartitionName=dynamic Nodes=dynamicns"""
+    )
+    
+    # Define both slurm_memory resource and slurm.dampen_memory, autoscale=true
+    # Expect dampen_memory (use 1G as 1% is too small) will be applied
+    partitions = [
+        make_partition("htc", False, False, slurm_memory="15g", dampen_memory=0.001),
+        make_partition("hpc", True, True, slurm_memory="14g", dampen_memory=0.001),
+        make_partition(
+            "dynamic",
+            False,
+            False,
+            dynamic_config="-Z Feature=dyn",
+            slurm_memory="13g",
+            dampen_memory=0.75,
+        ),
+    ]
+
+    writer = StringIO()
+    cli._partitions(partitions, writer, autoscale=True)
+    actual = "\n".join(
+        [x for x in writer.getvalue().splitlines() if not x.startswith("#")]
+    )
+    assert (
+        actual
+        == """PartitionName=htc Nodes=pre-[1-100] Default=NO DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=15360
+PartitionName=hpc Nodes=pre-[1-100] Default=YES DefMemPerCPU=3840 MaxTime=INFINITE State=UP
+Nodename=pre-[1-100] Feature=cloud STATE=CLOUD CPUs=4 ThreadsPerCore=1 RealMemory=15360
+Nodeset=dynamicns Feature=dyn
+PartitionName=dynamic Nodes=dynamicns"""
+    )
+
+
+def test_return_to_idle() -> None:
+    class MockNode:
+        def __init__(self, name: str, keep_alive: bool) -> None:
+            self.name = name
+            self.keep_alive = keep_alive
+    class MockNodeMgr:
+        def __init__(self) -> None:
+            self._expect = []
+
+        def expect(self, *names: str):
+            self._expect.append(set(names))
+
+        def shutdown_nodes(self, nodes: List[MockNode]) -> ShutdownResult:
+            actual = set()
+            for node in nodes:
+                assert not node.keep_alive
+                actual.add(node.name)
+            assert actual == self._expect[-1]
+            self._expect.pop()
+
+    class MockScontrol:
+        def __init__(self) -> None:
+            self._expect = []
+
+        def expect(self, *args: str, **kwargs) -> None:
+            self._expect.append((list(args), kwargs.get("return_value", "")))
+
+        def __call__(self, args: List[str]) -> str:
+            if args[0] == "show" and args[1] == "hostlist":
+                return args[2]
+            assert self._expect, f"Unexpected call to scontrol: {args}"
+            expected_args, return_value = self._expect.pop()
+            assert args == expected_args
+            return return_value
+
+
+    ccnodes_by_name = {"htc-1": MockNode("htc-1", True), "htc-2": MockNode("htc-2", False)}
+    config = {}
+    node_mgr = MockNodeMgr()
+    scontrol_func = MockScontrol()
+    snodes = [
+        {"NodeName": "htc-1", "State": "POWERING_DOWN+DOWN+CLOUD"},
+        {"NodeName": "htc-2", "State": "POWERED_DOWN+DOWN+CLOUD"},
+        {"NodeName": "unmanaged", "State": "POWERED_DOWN+DOWN"},
+    ]
+
+    def run_test():
+        cli.SlurmCLI._return_to_idle(config=config,
+                                     snodes=snodes,
+                                     ccnodes_by_name=ccnodes_by_name, 
+                                     node_mgr=node_mgr,
+                                     scontrol_func=scontrol_func,
+                                    )
+    node_mgr.expect("htc-2")
+    scontrol_func.expect("update", "nodename=htc-2", "state=idle")
+    run_test()
+    ccnodes_by_name.pop("htc-2")
+    snodes[1]["State"] = "POWERED_DOWN+IDLE+CLOUD"
+    run_test()
+    ccnodes_by_name["htc-1"].keep_alive = False
+    run_test()
+    config["slurm"] = {"return_to_idle": True}
+    node_mgr.expect("htc-2")
+    run_test()

--- a/slurm/test/slurmcc_test/testutil.py
+++ b/slurm/test/slurmcc_test/testutil.py
@@ -5,6 +5,7 @@ from hpc.autoscale.ccbindings.mock import MockClusterBinding
 from hpc.autoscale.clock import use_mock_clock
 from hpc.autoscale.node import nodemanager
 from hpc.autoscale.node.nodemanager import NodeManager
+from slurmcc import partition
 from slurmcc.cli import SlurmDriver
 from slurmcc.util import NativeSlurmCLI, set_slurm_cli
 
@@ -18,6 +19,7 @@ def _show_hostnames(expr: str) -> List[str]:
     """
     Purely used to mimic scontrol
     """
+    assert isinstance(expr, str)
     ret = []
     if "," in expr:
         for sub_expr in expr.split(","):
@@ -38,9 +40,14 @@ def _show_hostnames(expr: str) -> List[str]:
 
 
 def _show_hostlist(node_list: List[str]) -> str:
+    if len(node_list) == 1:
+        return node_list[0]
     by_prefix = hpcutil.partition(node_list, lambda n: n.split("-")[0])
     ret = []
     for prefix, names in by_prefix.items():
+        if len(names) == 1:
+            ret.append(names[0])
+            continue
         nums = []
         for name in names:
             try:
@@ -59,6 +66,8 @@ def _show_hostlist(node_list: List[str]) -> str:
                 last_num = min_num = num
             else:
                 last_num = num
+    if node_list:
+        assert ret, node_list
     return ",".join(ret)
 
 
@@ -67,17 +76,24 @@ class MockNativeSlurmCLI(NativeSlurmCLI):
         self.slurm_nodes: Dict[str, Dict] = {}
 
     def scontrol(self, args: List[str], retry: bool = True) -> str:
+        clear_caches()
         if args[0:2] == ["show", "hostnames"]:
             assert len(args) == 3
-            return "\n".join(_show_hostnames(args[-1]))
+            assert isinstance(args[-1], str)
+            ret = _show_hostnames(args[-1])
+            assert ret
+            assert isinstance(ret[0], str), ret[0]
+            return "\n".join(ret)
         
         if args[0:2] == ["show", "hostlist"]:
             assert len(args) == 3
+            assert args[-1]
             return _show_hostlist(args[-1].split(","))
 
         if args[0:2] == ["show", "nodes"]:
-            assert len(args) == 3
-            return self.show_nodes(args[2].split(","))
+            if len(args) == 3:
+                return self.show_nodes(args[2].split(","))
+            return self.show_nodes([])
 
         if args[0] == "update":
             entity, value = args[1].split("=")
@@ -93,6 +109,7 @@ class MockNativeSlurmCLI(NativeSlurmCLI):
 
     def show_nodes(self, node_names: List[str]) -> str:
         ret = []
+        node_names = node_names or list(self.slurm_nodes.keys())
         for node_name in node_names:
             assert (
                 node_name in self.slurm_nodes
@@ -101,20 +118,22 @@ class MockNativeSlurmCLI(NativeSlurmCLI):
             ret.append(
                 """
 NodeName=%(NodeName)s
-    NodeAddr=%(NodeAddr)s NodeHostName=%(NodeHostName)s AvailableFeatures=%(AvailableFeatures)s"""
+    NodeAddr=%(NodeAddr)s NodeHostName=%(NodeHostName)s AvailableFeatures=%(AvailableFeatures)s Partitions=%(Partitions)s"""
                 % snode
             )
 
         return "\n".join(ret)
 
-    def create_nodes(self, node_names: List[str], features: List[str] = []) -> None:
+    def create_nodes(self, node_names: List[str], features: List[str] = [], partitions: List[str] = []) -> None:
         for node_name in node_names:
             self.slurm_nodes[node_name] = {
                 "NodeName": node_name,
                 "NodeAddr": node_name,
                 "NodeHostName": node_name,
                 "AvailableFeatures": ",".join(features),
+                "Partitions": "dynamic" if "dyn" in features else node_name.split("-")[0]
             }
+        clear_caches()
 
 
 set_slurm_cli(MockNativeSlurmCLI())
@@ -189,3 +208,7 @@ def make_test_node_manager(cluster_name: str = "c1") -> NodeManager:
     driver.preprocess_node_mgr(config, node_mgr)
     assert config["nodearrays"]["hpc"]
     return node_mgr
+
+
+def clear_caches() -> None:
+    partition.Partition._SLURM_NODES_CACHE = None


### PR DESCRIPTION
Fixes issues with manually suspending nodes that do not use nodename==hostname.
Also fixes KeepAlive issues where the nodes would resume/resume_failed in a loop forever.
Adds azslurm return_to_idle command to help with this, rather than the pure shell implementation.