### PR TITLE
Add some runtime dependencies needed for our scripts.

### DIFF
--- a/slurm/install/rhel.sh
+++ b/slurm/install/rhel.sh
@@ -14,7 +14,7 @@ DISABLE_PMC=$3
 OS_VERSION=$(cat /etc/os-release  | grep VERSION_ID | cut -d= -f2 | cut -d\" -f2 | cut -d. -f1)
 
 yum -y install epel-release
-yum -y install munge
+yum -y install munge jq
 if [ "$OS_VERSION" -gt "7" ]; then
     dnf -y --enablerepo=powertools install -y perl-Switch
     PACKAGE_DIR=slurm-pkgs-rhel8

--- a/slurm/install/ubuntu.sh
+++ b/slurm/install/ubuntu.sh
@@ -20,7 +20,7 @@ fi
 
 apt -y install munge
  
-apt -y install libmysqlclient-dev libmariadbclient-dev-compat libssl-dev
+apt -y install libmysqlclient-dev libssl-dev jq
 
 if [ $UBUNTU_VERSION == 22.04 ]; then
     REPO=slurm-ubuntu-jammy


### PR DESCRIPTION
Jq is used by prolog scripts and in some cases is not present in the image.

mysql client libraries are replaced by mariadb. 

Note: With the exception of jq, most of these packages shouldnt be required once we fully move to PMC.