### PR TITLE
Add jwt build option to rpmbuild.

### DIFF
--- a/util/build-slurm.sh
+++ b/util/build-slurm.sh
@@ -23,7 +23,7 @@ function build_slurm() {
 
     case ${DISTRO_FAMILY} in
         suse)
-            zypper install --no-confirm bzip2 rpmbuild munge-devel pam-devel mysql-devel autoconf readline-devel
+            zypper install --no-confirm bzip2 rpmbuild munge-devel pam-devel mysql-devel autoconf readline-devel libjwt-devel
             ;;
         centos)
             CENTOS_VERSION=$(cat /etc/centos-release | sed 's/ /\n/g' | grep -E '[0-9.]+')
@@ -41,7 +41,7 @@ function build_slurm() {
              # munge is in EPEL
             yum -y install epel-release && yum -q makecache
             yum install -y make $PYTHON which rpm-build munge-devel munge-libs readline-devel openssl openssl-devel pam-devel perl-ExtUtils-MakeMaker gcc mysql mysql-devel wget gtk2-devel.x86_64 glib2-devel.x86_64 $LIBTOOL m4 automake rsync lua-devel
-            yum install -y http-parser-devel json-c-devel hwloc-devel
+            yum install -y http-parser-devel json-c-devel hwloc-devel libjwt-devel
             ;;
 
     esac
@@ -64,7 +64,7 @@ function build_slurm() {
         wget "${DOWNLOAD_URL}/${SLURM_PKG}"
     fi
 
-    rpmbuild --with mysql --define '_with_pmix --with-pmix=/opt/pmix/v4' --with=hwloc --with=lua --with=slurmrestd -ta ${SLURM_PKG}
+    rpmbuild --with mysql --define '_with_pmix --with-pmix=/opt/pmix/v4' --with=hwloc --with=lua --with=slurmrestd --with=jwt -ta ${SLURM_PKG}
 }
 
 function install_pmix() {


### PR DESCRIPTION
Hello,

This pull request adds --with=jwt option to the Slurm build package. This allows using JWT authentication with the Slurm Rest API (see https://slurm.schedmd.com/jwt.html).

Currently, we have to build our own packages due to the JWT authentication. So, including this feature in the standard packages would simplify our deployments.

Thanks for your help.