### PR TITLE
Add dbdhost name for primary scheduler.

### DIFF
--- a/slurm/install/install.py
+++ b/slurm/install/install.py
@@ -287,6 +287,7 @@ AccountingStorageTRES=gres/gpu
         variables={
             "accountdb": s.acct_url or "localhost",
             "dbuser": s.acct_user or "root",
+            "dbdhost": s.hostname,
             "storagepass": f"StoragePass={s.acct_pass}" if s.acct_pass else "#StoragePass=",
             "storage_parameters": "StorageParameters=SSL_CA=/etc/slurm/AzureCA.pem"
                                   if s.acct_cert_url

--- a/slurm/install/templates/slurmdbd.conf.template
+++ b/slurm/install/templates/slurmdbd.conf.template
@@ -15,7 +15,7 @@ AuthType=auth/munge
 #
 # slurmDBD info
 DbdAddr=localhost
-DbdHost=localhost
+DbdHost={dbdhost}
 #DbdPort=7031
 SlurmUser=slurm
 #MessageTimeout=300


### PR DESCRIPTION
"localhost" can work and does not cause a bug but this keeps the configuration more organized. "localhost" can cause confusion as backup slurmdbd is also "localhost"