### PR TITLE
Fix powertools installation for RHEL

### DIFF
--- a/slurm/install/rhel.sh
+++ b/slurm/install/rhel.sh
@@ -3,8 +3,8 @@
 # Licensed under the MIT License.
 #
 set -e
-INSALLED_FILE=/etc/azslurm-bins.installed
-if [ -e $INSALLED_FILE ]; then
+INSTALLED_FILE=/etc/azslurm-bins.installed
+if [ -e $INSTALLED_FILE ]; then
     exit 0
 fi
 
@@ -12,11 +12,16 @@ SLURM_ROLE=$1
 SLURM_VERSION=$2
 DISABLE_PMC=$3
 OS_VERSION=$(cat /etc/os-release  | grep VERSION_ID | cut -d= -f2 | cut -d\" -f2 | cut -d. -f1)
+OS_ID=$(cat /etc/os-release  | grep ^ID= | cut -d= -f2 | cut -d\" -f2 | cut -d. -f1)
 
 yum -y install epel-release
 yum -y install munge jq
 if [ "$OS_VERSION" -gt "7" ]; then
-    dnf -y --enablerepo=powertools install -y perl-Switch
+    if [ "${OS_ID,,}" = "rhel" ]; then
+        dnf -y install -y perl-Switch
+    else
+        dnf -y --enablerepo=powertools install -y perl-Switch
+    fi
     PACKAGE_DIR=slurm-pkgs-rhel8
 else
     yum -y install python3

--- a/slurm/install/rhel.sh
+++ b/slurm/install/rhel.sh
@@ -17,7 +17,7 @@ OS_ID=$(cat /etc/os-release  | grep ^ID= | cut -d= -f2 | cut -d\" -f2 | cut -d. 
 yum -y install epel-release
 yum -y install munge jq
 if [ "$OS_VERSION" -gt "7" ]; then
-    if [ "${OS_ID,,}" = "rhel" ]; then
+    if [ "${OS_ID,,}" == "rhel" ]; then
         dnf -y install -y perl-Switch
     else
         dnf -y --enablerepo=powertools install -y perl-Switch
@@ -62,7 +62,7 @@ if [ "$DISABLE_PMC" == "False" ]; then
             yum -y install $pkg-${SLURM_VERSION}.el${OS_VERSION} --disableexcludes slurm
         done
     fi
-    touch $INSALLED_FILE
+    touch $INSTALLED_FILE
 
     exit
 fi
@@ -84,4 +84,4 @@ if [ ${SLURM_ROLE} == "execute" ]; then
     done
 fi
 
-touch $INSALLED_FILE
+touch $INSTALLED_FILE


### PR DESCRIPTION
This PR is intended to fix issue #126 .
The powertools repository is not compatible nor required for RHEL only for CentOS
