### PR TITLE
Set as undefined the  inherited, but invalid, ComputerName attribute …

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -162,6 +162,9 @@ Autoscale = $Autoscale
     IsReturnProxy = false
     InitialCount = $configuration_slurm_ha_enabled
     Zone = $SchedulerHAZone
+    # Do not inherit property from node that is not used in nodearray
+    # The equivalent is ComputerNamePrefix for nodearray, however Cluster-init will handle renaming of all hosts in a VMSS
+    ComputerName := undefined
         [[[configuration]]]
         autoscale.enabled = false
         slurm.node_prefix = ${ifThenElse(NodeNamePrefix=="Cluster Prefix", StrJoin("-", ClusterName, ""), NodeNamePrefix)}


### PR DESCRIPTION
…on scheduler-ha nodearray

This should remove the "Target is null" exception when processing regexps("[^a-zA-Z0-9-]", undefined, "-")
Either way, this attribute, ComputerName, is not valid on a nodearray