### PR TITLE
leave a comment about 0 capacity unused partitions

### DIFF
--- a/slurm/src/slurmcc/cli.py
+++ b/slurm/src/slurmcc/cli.py
@@ -803,18 +803,18 @@ def _partitions(
             threads = 1
         def_mem_per_cpu = memory // cpus
 
-
+        comment_out = ""
+        if max_count <= 0:
+            writer.write(f"# The following partition has no capacity! {partition.name} - {partition.nodearray} - {partition.machine_type} \n")
+            comment_out = "# "
+        
         writer.write(
-            "PartitionName={} Nodes={} Default={} DefMemPerCPU={} MaxTime=INFINITE State=UP\n".format(
-                partition.name, partition.node_list, default_yn, def_mem_per_cpu
-            )
+            f"{comment_out}PartitionName={partition.name} Nodes={partition.node_list} Default={default_yn} DefMemPerCPU={def_mem_per_cpu} MaxTime=INFINITE State=UP\n"
         )
 
         state = "CLOUD" if autoscale else "FUTURE"
         writer.write(
-            "Nodename={} Feature=cloud STATE={} CPUs={} ThreadsPerCore={} RealMemory={}".format(
-                node_list, state, cpus, threads, memory
-            )
+           f"{comment_out}Nodename={node_list} Feature=cloud STATE={state} CPUs={cpus} ThreadsPerCore={threads} RealMemory={memory}"
         )
 
         if partition.gpu_count:

--- a/slurm/src/slurmcc/partition.py
+++ b/slurm/src/slurmcc/partition.py
@@ -104,6 +104,9 @@ class Partition:
     @property
     def node_list(self) -> str:
         if not self.dynamic_config:
+            static_nodes = self._static_all_nodes()
+            if not static_nodes:
+                return ""
             return slutil.to_hostlist(self._static_all_nodes())
         # with dynamic nodes, we only look at those defined in the partition
         if not self.__dynamic_node_list_cache:
@@ -349,10 +352,10 @@ def fetch_partitions(
 
             if limits.max_count <= 0:
                 logging.info(
-                    "Bucket has a max_count <= 0, defined for machinetype=='%s'. Skipping",
+                    "Bucket has a max_count <= 0, defined for machinetype=='%s'.",
                     machine_type,
                 )
-                continue
+                # keep this partition around, but we will ignore it when generating later.
 
             max_scaleset_size = buckets[0].max_placement_group_size
 


### PR DESCRIPTION
When users hit 0 capacity issues, currently the only way for them to detect that is by checking the logs. This PR will leave the definition of the partition in azure.conf, but will comment it out with a comment that this particular partition/nodearray/vm_size has 0 capacity.

For example, I have 0 capacity for the ND40 here, this is what azslurm partitions writes out (and azslurm scale would put into /etc/slurm/azure.conf)

\# The following partition has no capacity! htc - htc - Standard_ND40rs_v2
\# PartitionName=htc Nodes= Default=NO DefMemPerCPU=16343 MaxTime=INFINITE State=UP
\# Nodename=[] Feature=cloud STATE=CLOUD CPUs=40 ThreadsPerCore=1 RealMemory=653721 Gres=gpu:8