### PR TITLE
Bug Fix: Fix azslurm partitions command.

### DIFF
--- a/slurm/src/slurmcc/partition.py
+++ b/slurm/src/slurmcc/partition.py
@@ -113,7 +113,7 @@ class Partition:
             ret: List[str] = []
             all_slurm_nodes = Partition._slurm_nodes()
             for node in all_slurm_nodes:
-                partitions = node["Partitions"].split(",")
+                partitions = node.get("Partitions", "").split(",")
                 if self.name in partitions:
                     # only include nodes that have the same vm_size declared as a feature
                     features = (node.get("AvailableFeatures") or "").lower().split(",")


### PR DESCRIPTION
If some dynamic nodes get added on the command line without the feature set associated with dynamic partition, then slurm still registers those nodes but does not associate them with a partition. In "scontrol show nodes" the partition field then appears blank resulting in a key error. This fixes that.