### PR TITLE
Make resumeprogram return immediately after resuming node.

### DIFF
--- a/sbin/resume_program.sh
+++ b/sbin/resume_program.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 node_list=$(echo $@ | sed "s/ /,/g")
 source /opt/azurehpc/slurm/venv/bin/activate
-azslurm resume --node-list $node_list
+azslurm resume --node-list $node_list --no-wait
 exit $?


### PR DESCRIPTION
no-wait option makes the azslurm resume command return immediately and it does not hold up slurmscriptd until the node resumes. Without this option, slurmscriptd process keeps running until the node comes up, which can take 5 minutes or longer. This makes any other commands like "scontrol reconfigure" time out and subsequently all slurm commands timeout.