### PR TITLE
Add an srun interface for submitting parallel commands.

### DIFF
--- a/slurm/install/templates/slurm.conf.template
+++ b/slurm/install/templates/slurm.conf.template
@@ -24,6 +24,7 @@ SlurmctldLogFile=/var/log/slurmctld/slurmctld.log
 SlurmctldParameters=idle_on_node_suspend
 SlurmdDebug=debug
 SlurmdLogFile=/var/log/slurmd/slurmd.log
+DisableRootJobs=No
 # TopologyPlugin=topology/tree
 # If you use the TopologyPlugin you likely also want to use our
 # job submit plugin so that your jobs run on a single switch 


### PR DESCRIPTION
commands that need to be run across a range of compute nodes can be submitted through srun. The interface exposed is similar to subprocess but based on srun.

This does use the job scheduler.