### PR TITLE
Fix srun logging to output all stderr

### DIFF
--- a/slurm/src/slurmcc/topology.py
+++ b/slurm/src/slurmcc/topology.py
@@ -110,6 +110,8 @@ class Topology:
             stdout=output.stdout
         except slutil.SrunExitCodeException as e:
             log.error("Error running get_os_id command on host %s",self.hosts[0])
+            if e.stderr_content.strip("\n"):
+                log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
         except subprocesslib.TimeoutExpired:
@@ -166,6 +168,8 @@ class Topology:
             log.debug(output.stdout)
         except slutil.SrunExitCodeException as e:
             log.error("SHARP is disabled on cluster")
+            if e.stderr_content.strip("\n"):
+                log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
         except subprocesslib.TimeoutExpired:
@@ -196,6 +200,8 @@ class Topology:
             log.debug(path)
         except slutil.SrunExitCodeException as e:
             log.error("Error running check_ibstatus command on host %s",self.hosts[0])
+            if e.stderr_content.strip("\n"):
+                log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
         except subprocesslib.TimeoutExpired:
@@ -225,6 +231,8 @@ class Topology:
             output = slutil.srun(self.hosts, cmd, shell=True, partition=self.partition)
         except slutil.SrunExitCodeException as e:
             log.error("Error running retrieve_guids command on hosts")
+            if e.stderr_content.strip("\n"):
+                log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
         except subprocesslib.TimeoutExpired:
@@ -292,6 +300,8 @@ class Topology:
             log.debug(output.stdout)
         except slutil.SrunExitCodeException as e:
             log.error("Error running sharp_command on host %s",self.hosts[0])
+            if e.stderr_content.strip("\n"):
+                log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
         except subprocesslib.TimeoutExpired:

--- a/slurm/src/slurmcc/topology.py
+++ b/slurm/src/slurmcc/topology.py
@@ -110,7 +110,7 @@ class Topology:
             stdout=output.stdout
         except slutil.SrunExitCodeException as e:
             log.error("Error running get_os_id command on host %s",self.hosts[0])
-            if e.stderr_content.strip("\n"):
+            if e.stderr_content:
                 log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
@@ -168,7 +168,7 @@ class Topology:
             log.debug(output.stdout)
         except slutil.SrunExitCodeException as e:
             log.error("SHARP is disabled on cluster")
-            if e.stderr_content.strip("\n"):
+            if e.stderr_content:
                 log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
@@ -200,7 +200,7 @@ class Topology:
             log.debug(path)
         except slutil.SrunExitCodeException as e:
             log.error("Error running check_ibstatus command on host %s",self.hosts[0])
-            if e.stderr_content.strip("\n"):
+            if e.stderr_content:
                 log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
@@ -231,7 +231,7 @@ class Topology:
             output = slutil.srun(self.hosts, cmd, shell=True, partition=self.partition)
         except slutil.SrunExitCodeException as e:
             log.error("Error running retrieve_guids command on hosts")
-            if e.stderr_content.strip("\n"):
+            if e.stderr_content:
                 log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)
@@ -300,7 +300,7 @@ class Topology:
             log.debug(output.stdout)
         except slutil.SrunExitCodeException as e:
             log.error("Error running sharp_command on host %s",self.hosts[0])
-            if e.stderr_content.strip("\n"):
+            if e.stderr_content:
                 log.error(e.stderr_content)
             log.error(e.stderr)
             sys.exit(e.returncode)

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -14,13 +14,14 @@ from . import AzureSlurmError, custom_chaos_mode
 
 
 class SrunExitCodeException(Exception):
-    def __init__(self, returncode: int, stdout: str, stderr: str):
+    def __init__(self, returncode: int, stdout: str, stderr: str, stderr_content: str):
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+        self.stderr_content = stderr_content
         super().__init__(f"srun command failed with exit code {returncode}")
 class SrunOutput:
-    def __init__(self, returncode: int, stdout: str, stderr: str):
+    def __init__(self, returncode: int, stdout: str, stderr: str,):
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
@@ -61,7 +62,7 @@ class NativeSlurmCLIImpl(NativeSlurmCLI):
                 logging.error(f"Command: {srun_command} failed with return code {e.returncode}")
                 with open(temp_file_path, 'r') as f:
                     stderr_content = f.read()
-                raise SrunExitCodeException(returncode=e.returncode,stdout=e.stdout, stderr=f"{e.stderr}\n{stderr_content}")
+                raise SrunExitCodeException(returncode=e.returncode,stdout=e.stdout, stderr=e.stderr, stderr_content=stderr_content)
             except subprocesslib.TimeoutExpired:
                 logging.error("Srun command timed out!")
                 raise

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -62,6 +62,8 @@ class NativeSlurmCLIImpl(NativeSlurmCLI):
                 logging.error(f"Command: {srun_command} failed with return code {e.returncode}")
                 with open(temp_file_path, 'r') as f:
                     stderr_content = f.read()
+                    if not stderr_content.strip("\n"):
+                        stderr_content = None
                 raise SrunExitCodeException(returncode=e.returncode,stdout=e.stdout, stderr=e.stderr, stderr_content=stderr_content)
             except subprocesslib.TimeoutExpired:
                 logging.error("Srun command timed out!")

--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -61,7 +61,7 @@ class NativeSlurmCLIImpl(NativeSlurmCLI):
                 logging.error(f"Command: {srun_command} failed with return code {e.returncode}")
                 with open(temp_file_path, 'r') as f:
                     stderr_content = f.read()
-                raise SrunExitCodeException(returncode=e.returncode,stdout=e.stdout, stderr=stderr_content)
+                raise SrunExitCodeException(returncode=e.returncode,stdout=e.stdout, stderr=f"{e.stderr}\n{stderr_content}")
             except subprocesslib.TimeoutExpired:
                 logging.error("Srun command timed out!")
                 raise


### PR DESCRIPTION
edit srun interface to include stderr of srun process and srun command. Fix logging in topology.py to to log every line of stderr output from SrunExitCodeException.