### PR TITLE
Add slurm.role to 4.x templates

### DIFF
--- a/templates/slurm-beegfs.txt
+++ b/templates/slurm-beegfs.txt
@@ -35,6 +35,7 @@ Autoscale = $Autoscale
     AdditionalClusterInitSpecs = $SchedulerClusterInitSpecs
     
         [[[configuration]]]
+        slurm.role = scheduler
 
         [[[cluster-init cyclecloud/slurm:scheduler]]]
 
@@ -49,6 +50,7 @@ Autoscale = $Autoscale
     AdditionalClusterInitSpecs = $HPCClusterInitSpecs
 
         [[[configuration]]]
+        slurm.role = execute
         slurm.autoscale = true
         slurm.default_partition = true
         slurm.hpc = true
@@ -69,6 +71,7 @@ Autoscale = $Autoscale
 
 
         [[[configuration]]]
+        slurm.role = execute
         slurm.autoscale = true
         slurm.hpc = false
 

--- a/templates/slurm-cs.txt
+++ b/templates/slurm-cs.txt
@@ -50,6 +50,7 @@ Autoscale = $Autoscale
     IsReturnProxy = $ReturnProxy
 
         [[[configuration]]]
+        slurm.role = scheduler
 
         [[[network-interface eth0]]]
         AssociatePublicIpAddress = $UsePublicNetwork
@@ -60,12 +61,14 @@ Autoscale = $Autoscale
         ImageName = $SchedulerImageName
 
         [[[configuration]]]
+        slurm.role = login
         autoscale.enabled = false
         slurm.node_prefix = ${StrJoin("-", ClusterName, "")}
 
     [[node nodearraybase]]
     Abstract = true
         [[[configuration]]]
+        slurm.role = execute
         slurm.autoscale = true
         
         slurm.node_prefix = ${StrJoin("-", ClusterName, "")}

--- a/templates/slurm-custom.txt
+++ b/templates/slurm-custom.txt
@@ -69,6 +69,7 @@ Autoscale = $Autoscale
     AdditionalClusterInitSpecs = $SchedulerClusterInitSpecs
     
         [[[configuration]]]
+        slurm.role = scheduler
         cyclecloud.mounts.nfs_sched.disabled = true
         cyclecloud.mounts.nfs_shared.disabled = ${NFSType != "External"}
 
@@ -121,6 +122,7 @@ Autoscale = $Autoscale
 
 
         [[[configuration]]]
+        slurm.role = execute
         slurm.autoscale = true
         slurm.default_partition = true
         slurm.hpc = true
@@ -143,6 +145,7 @@ Autoscale = $Autoscale
 
 
         [[[configuration]]]
+        slurm.role = execute
         slurm.autoscale = true
         slurm.hpc = false
 

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -110,6 +110,7 @@ Autoscale = $Autoscale
     Zone = ${ifThenElse(configuration_slurm_ha_enabled, SchedulerZone, undefined)}
     
         [[[configuration]]]
+        slurm.role = scheduler
         # Disable NFS mount of built-in /sched since it is a local volume mount: cyclecloud.mounts.builtinsched
         cyclecloud.mounts.nfs_sched.disabled = ${UseBuiltinSched && !configuration_slurm_ha_enabled}
         cyclecloud.mounts.nfs_shared.disabled = ${UseBuiltinShared && !configuration_slurm_ha_enabled}
@@ -180,6 +181,7 @@ Autoscale = $Autoscale
 
         [[[cluster-init slurm:login:4.0.0]]]
         [[[configuration]]]
+        slurm.role = login
         autoscale.enabled = false
         slurm.node_prefix = ${ifThenElse(NodeNamePrefix=="Cluster Prefix", StrJoin("-", ClusterName, ""), NodeNamePrefix)}
         slurm.use_nodename_as_hostname = $NodeNameIsHostname
@@ -187,6 +189,7 @@ Autoscale = $Autoscale
     [[node nodearraybase]]
     Abstract = true
         [[[configuration]]]
+        slurm.role = execute
         slurm.autoscale = true
 
         slurm.node_prefix = ${ifThenElse(NodeNamePrefix=="Cluster Prefix", StrJoin("-", ClusterName, ""), NodeNamePrefix)}


### PR DESCRIPTION
Default chef attributes were used in 3.x to assign a value to slurm.role, but in our chefless implementation this is not possible at the moment.