### PR TITLE
change min node value to 0

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -342,7 +342,7 @@ Order = 10
         Description = The total number of HTC execute nodes to start
         DefaultValue = 100
         Config.Plugin = pico.form.NumberTextBox
-        Config.MinValue = 1
+        Config.MinValue = 0
         Config.IntegerOnly = true
 
         [[[parameter MaxHPCExecuteNodeCount]]]
@@ -350,7 +350,7 @@ Order = 10
         Description = The total number of HPC execute nodes to start
         DefaultValue = 16
         Config.Plugin = pico.form.NumberTextBox
-        Config.MinValue = 1
+        Config.MinValue = 0
         Config.IntegerOnly = true
 
         [[[parameter MaxGPUExecuteNodeCount]]]
@@ -358,7 +358,7 @@ Order = 10
         Description = The total number of GPU execute nodes to start
         DefaultValue = 8
         Config.Plugin = pico.form.NumberTextBox
-        Config.MinValue = 1
+        Config.MinValue = 0
         Config.IntegerOnly = true
 
         [[[parameter MaxDynamicExecuteCoreCount]]]


### PR DESCRIPTION
with the change to using Node count vs cores, there is no way to not use a paritition type.  Changing the `Config.MinValue = 0` for HTC, HPC and GPU will enable a value of 0 nodes in the UI, which will not build that partition.  It can also be added or removed later with azslurm scale.