### PR TITLE
Make slurm.imex.enabled into a configurable parameter in the UI

### DIFF
--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -248,7 +248,7 @@ Autoscale = $Autoscale
         slurm.hpc = true
         slurm.partition = gpu
         #Parameter to enable or disable IMEX service on a per-job basis default is False
-        #slurm.imex.enabled=$SlurmImexEnabled
+        slurm.imex.enabled=$SlurmImexEnabled
 
     [[nodearray dynamic]]
     Extends = nodearraybase


### PR DESCRIPTION
Make slurm.imex.enabled into a configurable parameter for gpu nodearray in the UI
Default value is set to false and needs to be checked for GB200  
![image](https://github.com/user-attachments/assets/a0af59ed-340c-4648-9774-5612a4b2d232)
