### PR TITLE
suppress warning logs on console for topology cli

### DIFF
--- a/azure-slurm/conf/logging.conf
+++ b/azure-slurm/conf/logging.conf
@@ -82,7 +82,7 @@ args=("/opt/azurehpc/slurm/logs/topology.log", "a", 1024 * 1024 * 5, 5)
 
 [handler_topologyConsoleHandler]
 class=StreamHandler
-level=WARNING
+level=ERROR
 formatter=simpleFormatter
 args=(sys.stderr,)
 


### PR DESCRIPTION
default logs on command line to be errors only, suppress warnings