### PR TITLE
Large cluster bugfix: max arg limit reached

### DIFF
--- a/slurm/src/slurmcc/util.py
+++ b/slurm/src/slurmcc/util.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
+import os
 import random
 import subprocess as subprocesslib
 import time
@@ -48,14 +49,30 @@ def is_slurmctld_up() -> bool:
         return False
 
 
+# Can be adjusted via ENV here, in case even 500 is too large for max args limits.
+MAX_NODES_IN_LIST = int(os.getenv("AZSLURM_MAX_NODES_IN_LIST", 500))
 def show_nodes(node_list: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+    return _show_nodes(node_list, MAX_NODES_IN_LIST)
+
+
+def _show_nodes(node_list: Optional[List[str]], max_nodes_in_list: int) -> List[Dict[str, Any]]:
     args = ["show", "nodes"]
     if not is_autoscale_enabled():
         args.append("--future")
-    if node_list:
-        args.append(",".join(node_list))
-    stdout = scontrol(args)
-    return parse_show_nodes(stdout)
+
+    if not node_list:
+        stdout = scontrol(args)
+        return parse_show_nodes(stdout)
+    
+    # Break up names, so we don't hit max arg length limits.
+    ret = []
+    for x in range(0, len(node_list), MAX_NODES_IN_LIST):
+        sub_list = node_list[x: x + MAX_NODES_IN_LIST]
+        if sub_list:
+            sub_args = args + [",".join(sub_list)]
+            stdout = scontrol(sub_args)
+            ret.extend(parse_show_nodes(stdout))
+    return ret
 
 
 def parse_show_nodes(stdout: str) -> List[Dict[str, Any]]:
@@ -80,29 +97,50 @@ def parse_show_nodes(stdout: str) -> List[Dict[str, Any]]:
 
 
 def to_hostlist(nodes: Union[str, List[str]], scontrol_func: Callable=scontrol) -> str:
+    return _to_hostlist(nodes, scontrol_func=scontrol, max_nodes_in_list=MAX_NODES_IN_LIST)
+
+
+def _to_hostlist(nodes: Union[str, List[str]], scontrol_func: Callable=scontrol, max_nodes_in_list: int=MAX_NODES_IN_LIST) -> str:
     """
     convert name-[1-5] into name-1 name-2 name-3 name-4 name-5
     """
     assert nodes
     for n in nodes:
         assert n
+    
     if isinstance(nodes, list):
         nodes_str = ",".join(nodes)
     else:
         nodes_str = nodes
     # prevent poor sorting of nodes and getting node lists like htc-1,htc-10-19, htc-2, htc-20-29 etc
     sorted_nodes = sorted(nodes_str.split(","), key=get_sort_key_func(is_hpc=False))
-    nodes_str = ",".join(sorted_nodes)
-    return scontrol_func(["show", "hostlist", nodes_str])
+    ret = []
+    for i in range(0, len(sorted_nodes), max_nodes_in_list):
+
+        nodes_str = ",".join(sorted_nodes[i: i + max_nodes_in_list])
+        ret.append(scontrol_func(["show", "hostlist", nodes_str]))
+    return ",".join(ret)
 
 
 def from_hostlist(hostlist_expr: str) -> List[str]:
+    return _from_hostlist(hostlist_expr, MAX_NODES_IN_LIST)
+
+
+def _from_hostlist(hostlist_expr: str, max_nodes_in_list: int) -> List[str]:
     """
     convert name-1,name-2,name-3,name-4,name-5 into name-[1-5]
     """
     assert isinstance(hostlist_expr, str)
-    stdout = scontrol(["show", "hostnames", hostlist_expr])
-    return [x.strip() for x in stdout.split()]
+
+    sub_exprs = hostlist_expr.split(",")
+    ret = []
+    for i in range(0, len(sub_exprs), max_nodes_in_list):
+        sub_expr = ",".join(sub_exprs[i: i + max_nodes_in_list])
+        if not sub_expr:
+            continue
+        stdout = scontrol(["show", "hostnames", sub_expr])
+        ret.extend([x.strip() for x in stdout.split()])
+    return ret
 
 
 def retry_rest(func: Callable, attempts: int = 5) -> Any:

--- a/slurm/test/slurmcc_test/testutil.py
+++ b/slurm/test/slurmcc_test/testutil.py
@@ -7,7 +7,7 @@ from hpc.autoscale.node import nodemanager
 from hpc.autoscale.node.nodemanager import NodeManager
 from slurmcc import partition
 from slurmcc.cli import SlurmDriver
-from slurmcc.util import NativeSlurmCLI, set_slurm_cli
+from slurmcc.util import NativeSlurmCLI, set_slurm_cli, SrunOutput
 
 use_mock_clock()
 
@@ -106,6 +106,9 @@ class MockNativeSlurmCLI(NativeSlurmCLI):
                 raise RuntimeError(f"Unknown args {args}")
             return ""
         raise RuntimeError(f"Unexpected command - {args}")
+    
+    def srun(self, hostlist: List[str], user_command: str, timeout: int, shell: bool, partition: str, gpus: int) -> SrunOutput:
+        raise RuntimeError("Not implemented")
 
     def show_nodes(self, node_names: List[str]) -> str:
         ret = []

--- a/slurm/test/slurmcc_test/util_test.py
+++ b/slurm/test/slurmcc_test/util_test.py
@@ -1,4 +1,5 @@
-from slurmcc.util import to_hostlist, get_sort_key_func
+from slurmcc.util import to_hostlist, get_sort_key_func, run, _show_nodes, set_slurm_cli, _from_hostlist, _to_hostlist
+from slurmcc_test.testutil import MockNativeSlurmCLI
 from typing import List
 
 def scontrol_func(args: List[str], retry: bool = True) -> str:
@@ -35,3 +36,54 @@ def test_get_sort_key_func() -> None:
 def test_to_hostlist() -> None:
     assert "name-1,dyn" == to_hostlist(["name-1","dyn"], scontrol_func)
     assert "name-1,dyn" == to_hostlist(["dyn","name-1"], scontrol_func)
+
+
+def test_show_nodes() -> None:
+    # no differences based on splitting
+    cli = MockNativeSlurmCLI()
+    node_list = ["htc-1", "htc-2", "htc-3", "htc-4"]
+    set_slurm_cli(cli)
+    cli.create_nodes(node_list, ["cloud"], ["htc"])
+    complete = _show_nodes(node_list, 4)
+    split = _show_nodes(node_list, 2)
+    assert split == complete
+
+
+def test_from_hostlist() -> None:
+    # becomes so large we actually can't express htc-[min-max]
+    # so the final result is actually different
+    cli = MockNativeSlurmCLI()
+    node_list = ["htc-1", "htc-2", "htc-3", "htc-4"]
+    set_slurm_cli(cli)
+    def simple_scontrol(args, ignore):
+        assert args[0] == "show"
+        assert args[1] == "hostnames"
+        if args[2] == "htc-1,htc-2":
+            return "htc-[1-2]"
+        if args[2] == "htc-3,htc-4":
+            return "htc-[3-4]"
+        if args[2] == "htc-1,htc-2,htc-3,htc-4":
+            return "htc-[1-4]"
+        raise RuntimeError(args)
+        
+    
+    cli.create_nodes(node_list, ["cloud"], ["htc"])
+    cli.scontrol = simple_scontrol
+    complete = _from_hostlist(",".join(node_list), 4)
+    split = _from_hostlist(",".join(node_list), 2)
+    assert split != complete
+    assert complete == ["htc-[1-4]"]
+    assert split == ["htc-[1-2]", "htc-[3-4]"]
+
+
+def test_to_hostlist() -> None:
+    # no changes based on splitting
+    # confirmed this caused a failure with over 2k nodes
+    # dropping to 500 fixed the issue
+    cli = MockNativeSlurmCLI()
+    node_list = ["htc-1", "htc-2", "htc-3", "htc-4"]
+    set_slurm_cli(cli)
+    cli.scontrol = scontrol_func  # already implemented fake to hostlist
+    complete = _to_hostlist(node_list, max_nodes_in_list=4)
+    split = _to_hostlist(node_list, max_nodes_in_list=2)
+    assert split == complete


### PR DESCRIPTION
3.x implementation of max arg fix - when invoking scontrol with variable length args (i.e. lists of nodes) cap them at 500. There is an environment variable that can be changed - AZSLURM_MAX_NODES_IN_LIST - if even 500 is too many.