### PR TITLE
Add slurm health check configuration.

### DIFF
--- a/azure-slurm-install/templates/slurm.conf.template
+++ b/azure-slurm-install/templates/slurm.conf.template
@@ -50,6 +50,17 @@ SuspendProgram=/opt/azurehpc/slurm/suspend_program.sh
 SchedulerParameters=max_switch_wait=24:00:00
 # Only used with dynamic node partitions. 
 MaxNodeCount={max_node_count}
+
+## Node HealthChecks related  configurations
+
+## The interval in seconds between executions of HealthCheckProgram. Setting the value to zero disables execution.
+HealthCheckInterval={health_interval}
+## Identify what node states should execute the HealthCheckProgram. Multiple state values may be specified with a comma separator. The default value is ANY to execute on nodes in any state
+HealthCheckNodeState=ANY
+## Fully qualified pathname of a script to execute as user root periodically on all compute nodes that are not in the NOT_RESPONDING state.
+HealthCheckProgram={health_program}
+
+
 # This as the partition definitions managed by azslurm partitions > /sched/azure.conf
 Include azure.conf
 # If slurm.accounting.enabled=true this will setup slurmdbd

--- a/templates/slurm.txt
+++ b/templates/slurm.txt
@@ -30,6 +30,7 @@ Autoscale = $Autoscale
         slurm.user.gid = 11100
         munge.user.uid = 11101
         munge.user.gid = 11101
+        slurm.enable_healthchecks = true
         slurm.accounting.enabled = $configuration_slurm_accounting_enabled
         slurm.accounting.url = $configuration_slurm_accounting_url
         slurm.accounting.user = $configuration_slurm_accounting_user


### PR DESCRIPTION
Enable healthagent based healthcheck configuration for slurm clusters.

If in the template `slurm.enable_healthchecks` is set to `false`, then `HealthCheckInterval` parameter is set to 0 which disables Healthchecking in slurm. (healthagent always runs regardless).

HealthCheckInterval is set 120secs.

This also enables health epilog.