### PR TITLE
fix: space after ] in 00-install.sh

### DIFF
--- a/specs/scheduler/cluster-init/scripts/00-install.sh
+++ b/specs/scheduler/cluster-init/scripts/00-install.sh
@@ -25,7 +25,7 @@ find_python3() {
 
 install_python3() {
     PYTHON_BIN=find_python3
-    if [ -z "$PYTHON_BIN"]; then
+    if [ -z "$PYTHON_BIN" ]; then
         return 0
     fi
     # NOTE: based off of healthagent 00-install.sh, but we have different needs - we don't need the devel/systemd paths.


### PR DESCRIPTION
00-install.sh fails due to a missing space between a bracket under some shells.