### PR TITLE
Update toopology cli to read gpu rack info from slurm features

### DIFF
--- a/azure-slurm/slurmcc/topology.py
+++ b/azure-slurm/slurmcc/topology.py
@@ -100,7 +100,7 @@ class Topology:
         validate_partition(self.partition)
         partition_cmd = f'-p {self.partition} '
         host_cmd = f'scontrol show hostnames $(sinfo -p {self.partition} -o "%N" -h)'
-        partition_states = "powered_down,powering_up,powering_down,power_down,drain,drained,draining,unknown,down,no_respond,fail,reboot"
+        partition_states = "powered_down,powering_up,powering_down,power_down,drained,draining,unknown,down,no_respond,fail,reboot"
         sinfo_cmd = f'sinfo {partition_cmd}-t {partition_states} -o "%N" -h'
         down_cmd = f'scontrol show hostnames $({sinfo_cmd})'
         hosts=get_hostlist(host_cmd)


### PR DESCRIPTION
get rid of ssh interface needed for block topology and read in slurm features from scontrol show node.
allow drain state nodes in topology