### PR TITLE
Output sorted list of blocks for block topology cli

### DIFF
--- a/azure-slurm/slurmcc/topology.py
+++ b/azure-slurm/slurmcc/topology.py
@@ -634,18 +634,18 @@ def output_block_nodelist(topology_input, table=False):
         If table=False: JSON string of blocks sorted by size
         If table=True: string in tabular format with block names, sizes, and node lists
     """
-    
+
     # Read content from file or use string directly
     if Path(topology_input).exists():
         with open(topology_input, 'r', encoding='utf-8') as f:
             content = f.read()
     else:
         content = topology_input
-    
+
     # Check if it's a block topology
     if 'BlockName=' not in content:
         raise ValueError("Input is not a block topology format")
-    
+
     # Parse blocks
     blocks = []
     lines = content.strip().split('\n')
@@ -655,7 +655,7 @@ def output_block_nodelist(topology_input, table=False):
         line = line.strip()
         if not line or line.startswith('#'):
             continue
-            
+
         # Parse BlockName lines
         if line.startswith('BlockName='):
             # Extract block name and nodes
@@ -664,16 +664,16 @@ def output_block_nodelist(topology_input, table=False):
                 block_name = match.group(1)
                 nodes_str = match.group(2)
                 nodelist = [node.strip() for node in nodes_str.split(',')]
-                
+
                 blocks.append({
                     'blockname': block_name,
                     'size': len(nodelist),
                     'nodelist': nodelist
                 })
-    
+
     # Sort blocks by size (smallest to largest)
     blocks.sort(key=lambda x: x['size'])
-    
+
     if not table:
         # Return JSON format
         return json.dumps(blocks, indent=2)
@@ -682,7 +682,7 @@ def output_block_nodelist(topology_input, table=False):
         if not blocks:
             print("No blocks found in topology")
             return
-            
+
         # Calculate column widths
         max_blockname = max(len(b['blockname']) for b in blocks)
         max_blockname = max(max_blockname, len("Block Name"))
@@ -698,9 +698,10 @@ def output_block_nodelist(topology_input, table=False):
             if len(nodes_str) > 50:
                 nodes_str = nodes_str[:47] + '...'
             lines.append(f"{block['blockname']:<{max_blockname}} | {block['size']:>6} | {nodes_str}")
-        
+
         # Summary
         lines.append(f"\nTotal blocks: {len(blocks)}")
         lines.append(f"Total nodes: {sum(b['size'] for b in blocks)}")
 
         return "\n".join(lines) + "\n"
+    

--- a/azure-slurm/slurmcc/topology.py
+++ b/azure-slurm/slurmcc/topology.py
@@ -8,6 +8,7 @@ import datetime
 from . import util as slutil
 from enum import Enum
 from pssh.exceptions import Timeout
+import json
 import re
 
 log=logging.getLogger('topology')
@@ -620,4 +621,85 @@ class Topology:
         else:
             print(content, end='')
             log.info("Printed slurm topology")
+
+def output_block_nodelist(topology_input, table=False):
+    """
+    Parse a topology file or string and output node information.
+    
+    Args:
+        topology_input: Either a file path (str) or topology content (str)
+        table: If True, output in tabular format; if False, output as JSON
+    
+    Returns:
+        If table=False: JSON string of blocks sorted by size
+        If table=True: None (prints tabular output)
+    """
+    
+    # Read content from file or use string directly
+    if Path(topology_input).exists():
+        with open(topology_input, 'r', encoding='utf-8') as f:
+            content = f.read()
+    else:
+        content = topology_input
+    
+    # Check if it's a block topology
+    if 'BlockName=' not in content:
+        raise ValueError("Input is not a block topology format")
+    
+    # Parse blocks
+    blocks = []
+    lines = content.strip().split('\n')
+
+    for line in lines:
+        # Skip comments and empty lines
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+            
+        # Parse BlockName lines
+        if line.startswith('BlockName='):
+            # Extract block name and nodes
+            match = re.match(r'BlockName=([\w-]+)\s+Nodes=(.+)', line)
+            if match:
+                block_name = match.group(1)
+                nodes_str = match.group(2)
+                nodelist = [node.strip() for node in nodes_str.split(',')]
+                
+                blocks.append({
+                    'blockname': block_name,
+                    'size': len(nodelist),
+                    'nodelist': nodelist
+                })
+    
+    # Sort blocks by size (smallest to largest)
+    blocks.sort(key=lambda x: x['size'])
+    
+    if not table:
+        # Return JSON format
+        return json.dumps(blocks, indent=2)
+    else:
+        # Print tabular format
+        if not blocks:
+            print("No blocks found in topology")
+            return
+            
+        # Calculate column widths
+        max_blockname = max(len(b['blockname']) for b in blocks)
+        max_blockname = max(max_blockname, len("Block Name"))
+        
+        # Header
+        print(f"{'Block Name':<{max_blockname}} | {'Size':>6} | {'Nodes'}")
+        print(f"{'-' * max_blockname}-+-{'-' * 8}-+-{'-' * 50}")
+        
+        # Data rows
+        for block in blocks:
+            nodes_str = ', '.join(block['nodelist'])
+            # Truncate long node lists for display
+            if len(nodes_str) > 50:
+                nodes_str = nodes_str[:47] + '...'
+            print(f"{block['blockname']:<{max_blockname}} | {block['size']:>6} | {nodes_str}")
+        
+        # Summary
+        print(f"\nTotal blocks: {len(blocks)}")
+        print(f"Total nodes: {sum(b['size'] for b in blocks)}")
             

--- a/azure-slurm/slurmcc/topology.py
+++ b/azure-slurm/slurmcc/topology.py
@@ -632,7 +632,7 @@ def output_block_nodelist(topology_input, table=False):
     
     Returns:
         If table=False: JSON string of blocks sorted by size
-        If table=True: None (prints tabular output)
+        If table=True: string in tabular format with block names, sizes, and node lists
     """
     
     # Read content from file or use string directly
@@ -686,20 +686,21 @@ def output_block_nodelist(topology_input, table=False):
         # Calculate column widths
         max_blockname = max(len(b['blockname']) for b in blocks)
         max_blockname = max(max_blockname, len("Block Name"))
-        
+        lines = []
         # Header
-        print(f"{'Block Name':<{max_blockname}} | {'Size':>6} | {'Nodes'}")
-        print(f"{'-' * max_blockname}-+-{'-' * 8}-+-{'-' * 50}")
-        
+        lines.append(f"{'Block Name':<{max_blockname}} | {'Size':>6} | {'Nodes'}")
+        lines.append(f"{'-' * max_blockname}-+-{'-' * 8}-+-{'-' * 50}")
+
         # Data rows
         for block in blocks:
             nodes_str = ', '.join(block['nodelist'])
             # Truncate long node lists for display
             if len(nodes_str) > 50:
                 nodes_str = nodes_str[:47] + '...'
-            print(f"{block['blockname']:<{max_blockname}} | {block['size']:>6} | {nodes_str}")
+            lines.append(f"{block['blockname']:<{max_blockname}} | {block['size']:>6} | {nodes_str}")
         
         # Summary
-        print(f"\nTotal blocks: {len(blocks)}")
-        print(f"Total nodes: {sum(b['size'] for b in blocks)}")
-            
+        lines.append(f"\nTotal blocks: {len(blocks)}")
+        lines.append(f"Total nodes: {sum(b['size'] for b in blocks)}")
+
+        return "\n".join(lines) + "\n"


### PR DESCRIPTION
add new function output_block_nodelist that  takes in a topology file or string and outputs a sorted list of blocks by the size of their node list in either json or tabular format. 
With a topology like this 
```
# Number of Nodes in block1: 16
# ClusterUUID and CliqueID: 5e797fc6-0f46-421a-8724-0e102c0f723c
BlockName=block_5e797fc6-0f46-421a-8724-0e102c0f723c_1234 Nodes=hpcbench-hpc-9,hpcbench-hpc-13,hpcbench-hpc-17,hpcbench-hpc-21,hpcbench-hpc-25,hpcbench-hpc-29,hpcbench-hpc-33,hpcbench-hpc-37,hpcbench-hpc-41,hpcbench-hpc-45,hpcbench-hpc-49,hpcbench-hpc-53,hpcbench-hpc-57,hpcbench-hpc-61,hpcbench-hpc-65,hpcbench-hpc-69
# Number of Nodes in block2: 13
# ClusterUUID and CliqueID: 5e797fc6-0f46-421a-8724-0e102c0f721e
BlockName=block_5e797fc6-0f46-421a-8724-0e102c0f721e_23456 Nodes=hpcbench-hpc-22,hpcbench-hpc-26,hpcbench-hpc-30,hpcbench-hpc-34,hpcbench-hpc-38,hpcbench-hpc-42,hpcbench-hpc-46,hpcbench-hpc-50,hpcbench-hpc-54,hpcbench-hpc-58,hpcbench-hpc-62,hpcbench-hpc-66,hpcbench-hpc-70
# Number of Nodes in block3: 18
# ClusterUUID and CliqueID: 5e797fc6-0f46-421a-8724-0e102c0f724b
BlockName=block_5e797fc6-0f46-421a-8724-0e102c0f724b_34567 Nodes=hpcbench-hpc-3,hpcbench-hpc-7,hpcbench-hpc-11,hpcbench-hpc-15,hpcbench-hpc-19,hpcbench-hpc-23,hpcbench-hpc-27,hpcbench-hpc-31,hpcbench-hpc-35,hpcbench-hpc-39,hpcbench-hpc-43,hpcbench-hpc-47,hpcbench-hpc-51,hpcbench-hpc-55,hpcbench-hpc-59,hpcbench-hpc-63,hpcbench-hpc-67,hpcbench-hpc-71
# Number of Nodes in block4: 2
# ClusterUUID and CliqueID: 5e797fc6-0f46-421a-8724-0e102c0f722a
BlockName=block_5e797fc6-0f46-421a-8724-0e102c0f722a_56789 Nodes=hpcbench-hpc-4,hpcbench-hpc-8
BlockSizes=1
```
output_block_nodelist will return a sorted json like this 
```
[root@nvidia4-scheduler ~]# /opt/azurehpc/slurm/venv/bin/python3.11 test_topo.py topo.conf
[
  {
    "blockname": "block_5e797fc6-0f46-421a-8724-0e102c0f722a_56789",
    "size": 2,
    "nodelist": [
      "hpcbench-hpc-4",
      "hpcbench-hpc-8"
    ]
  },
  {
    "blockname": "block_5e797fc6-0f46-421a-8724-0e102c0f721e_23456",
    "size": 13,
    "nodelist": [
      "hpcbench-hpc-22",
      "hpcbench-hpc-26",
      "hpcbench-hpc-30",
      "hpcbench-hpc-34",
      "hpcbench-hpc-38",
      "hpcbench-hpc-42",
      "hpcbench-hpc-46",
      "hpcbench-hpc-50",
      "hpcbench-hpc-54",
      "hpcbench-hpc-58",
      "hpcbench-hpc-62",
      "hpcbench-hpc-66",
      "hpcbench-hpc-70"
    ]
  },
  {
    "blockname": "block_5e797fc6-0f46-421a-8724-0e102c0f723c_1234",
    "size": 16,
    "nodelist": [
      "hpcbench-hpc-9",
      "hpcbench-hpc-13",
      "hpcbench-hpc-17",
      "hpcbench-hpc-21",
      "hpcbench-hpc-25",
      "hpcbench-hpc-29",
      "hpcbench-hpc-33",
      "hpcbench-hpc-37",
      "hpcbench-hpc-41",
      "hpcbench-hpc-45",
      "hpcbench-hpc-49",
      "hpcbench-hpc-53",
      "hpcbench-hpc-57",
      "hpcbench-hpc-61",
      "hpcbench-hpc-65",
      "hpcbench-hpc-69"
    ]
  },
  {
    "blockname": "block_5e797fc6-0f46-421a-8724-0e102c0f724b_34567",
    "size": 18,
    "nodelist": [
      "hpcbench-hpc-3",
      "hpcbench-hpc-7",
      "hpcbench-hpc-11",
      "hpcbench-hpc-15",
      "hpcbench-hpc-19",
      "hpcbench-hpc-23",
      "hpcbench-hpc-27",
      "hpcbench-hpc-31",
      "hpcbench-hpc-35",
      "hpcbench-hpc-39",
      "hpcbench-hpc-43",
      "hpcbench-hpc-47",
      "hpcbench-hpc-51",
      "hpcbench-hpc-55",
      "hpcbench-hpc-59",
      "hpcbench-hpc-63",
      "hpcbench-hpc-67",
      "hpcbench-hpc-71"
    ]
  }
]
```
or a tabular format like this 
```
[root@nvidia4-scheduler ~]# /opt/azurehpc/slurm/venv/bin/python3.11 test_topo.py topo.conf table
Block Name                                       |   Size | Nodes
-------------------------------------------------+----------+---------------------------------------------------
block_5e797fc6-0f46-421a-8724-0e102c0f722a_56789 |      2 | hpcbench-hpc-4, hpcbench-hpc-8
block_5e797fc6-0f46-421a-8724-0e102c0f721e_23456 |     13 | hpcbench-hpc-22, hpcbench-hpc-26, hpcbench-hpc-...
block_5e797fc6-0f46-421a-8724-0e102c0f723c_1234  |     16 | hpcbench-hpc-9, hpcbench-hpc-13, hpcbench-hpc-1...
block_5e797fc6-0f46-421a-8724-0e102c0f724b_34567 |     18 | hpcbench-hpc-3, hpcbench-hpc-7, hpcbench-hpc-11...

Total blocks: 4
Total nodes: 49
```