### PR TITLE
download epel-release at build time

### DIFF
--- a/azure-slurm-install/package.py
+++ b/azure-slurm-install/package.py
@@ -32,23 +32,15 @@ def execute() -> None:
         f"dist/azure-slurm-install-pkg-{version}.tar.gz", "w"
     )
 
-    def _download_file(url: str, dest: str) -> None:
-        response = requests.get(url, stream=True)
+    def _download(url: str, dest: str) -> None:
+        response = requests.get(url, stream=True, timeout=60)
         response.raise_for_status()
         with open(dest, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
+
     artifacts_dir = "artifacts"
     os.makedirs(artifacts_dir, exist_ok=True)
-
-    epel8_url = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-    epel9_url = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-
-    epel8_dest = os.path.join(artifacts_dir, "epel-release-latest-8.noarch.rpm")
-    epel9_dest = os.path.join(artifacts_dir, "epel-release-latest-9.noarch.rpm")
-
-    _download_file(epel8_url, epel8_dest)
-    _download_file(epel9_url, epel9_dest)
 
     def _add(name: str, path: Optional[str] = None, mode: Optional[int] = None) -> None:
         path = path or name
@@ -61,6 +53,12 @@ def execute() -> None:
         with open(path, "rb") as fr:
             tf.addfile(tarinfo, fr)
 
+    epel_versions = ["8", "9"]
+    for ver in epel_versions:
+        url = f"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{ver}.noarch.rpm"
+        dest = os.path.join(artifacts_dir, f"epel-release-latest-{ver}.noarch.rpm")
+        _download(url, dest)
+        _add(dest, dest)
     _add("install.sh", "install.sh", mode=os.stat("install.sh")[0])
     _add("install_logging.conf", "conf/install_logging.conf")
     _add("installlib.py", "installlib.py")
@@ -77,8 +75,6 @@ def execute() -> None:
     _add("suse.sh", "suse.sh", 600)
     _add("start-services.sh", "start-services.sh", 555)
     _add("capture_logs.sh", "capture_logs.sh", 755)
-    _add(epel8_dest, epel8_dest)
-    _add(epel9_dest, epel9_dest)
 
     for fil in os.listdir("templates"):
         if os.path.isfile(f"templates/{fil}"):

--- a/azure-slurm-install/package.py
+++ b/azure-slurm-install/package.py
@@ -33,11 +33,14 @@ def execute() -> None:
     )
 
     def _download(url: str, dest: str) -> None:
-        response = requests.get(url, stream=True, timeout=60)
-        response.raise_for_status()
-        with open(dest, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
+        try:
+            response = requests.get(url, stream=True, timeout=60)
+            response.raise_for_status()
+            with open(dest, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        except requests.RequestException as e:
+            print(f"Error downloading {url}: {e}")
 
     artifacts_dir = "artifacts"
     os.makedirs(artifacts_dir, exist_ok=True)

--- a/azure-slurm-install/package.py
+++ b/azure-slurm-install/package.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import tarfile
+import requests
 from typing import Optional
 
 def execute() -> None:
@@ -31,6 +32,24 @@ def execute() -> None:
         f"dist/azure-slurm-install-pkg-{version}.tar.gz", "w"
     )
 
+    def _download_file(url: str, dest: str) -> None:
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+    artifacts_dir = "artifacts"
+    os.makedirs(artifacts_dir, exist_ok=True)
+
+    epel8_url = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+    epel9_url = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+
+    epel8_dest = os.path.join(artifacts_dir, "epel-release-latest-8.noarch.rpm")
+    epel9_dest = os.path.join(artifacts_dir, "epel-release-latest-9.noarch.rpm")
+
+    _download_file(epel8_url, epel8_dest)
+    _download_file(epel9_url, epel9_dest)
+
     def _add(name: str, path: Optional[str] = None, mode: Optional[int] = None) -> None:
         path = path or name
         tarinfo = tarfile.TarInfo(f"azure-slurm-install/{name}")
@@ -58,6 +77,8 @@ def execute() -> None:
     _add("suse.sh", "suse.sh", 600)
     _add("start-services.sh", "start-services.sh", 555)
     _add("capture_logs.sh", "capture_logs.sh", 755)
+    _add(epel8_dest, epel8_dest)
+    _add(epel9_dest, epel9_dest)
 
     for fil in os.listdir("templates"):
         if os.path.isfile(f"templates/{fil}"):

--- a/azure-slurm-install/rhel.sh
+++ b/azure-slurm-install/rhel.sh
@@ -17,11 +17,7 @@ fi
 #Almalinux 8/9 and RockyLinux 8/9 both need epel-release to install libjwt for slurm packages 
 enable_epel() {
     if ! rpm -qa | grep -q "^epel-release-"; then
-        if [ "${OS_ID,,}" == "rhel" ]; then
-            yum -y install artifacts/epel-release-latest-${OS_VERSION}.noarch.rpm
-        else
-            yum -y install epel-release
-        fi
+        yum -y install artifacts/epel-release-latest-${OS_VERSION}.noarch.rpm
     fi
     if [ "${OS_ID}" == "almalinux" ]; then
         if [ "$OS_VERSION" == "8" ]; then

--- a/azure-slurm-install/rhel.sh
+++ b/azure-slurm-install/rhel.sh
@@ -18,7 +18,7 @@ fi
 enable_epel() {
     if ! rpm -qa | grep -q "^epel-release-"; then
         if [ "${OS_ID,,}" == "rhel" ]; then
-            yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm
+            yum -y install artifacts/epel-release-latest-${OS_VERSION}.noarch.rpm
         else
             yum -y install epel-release
         fi

--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3.11
 RUN pip3.11 install --upgrade setuptools
 RUN pip3.11 install --upgrade wheel
+RUN pip3.11 install requests


### PR DESCRIPTION
creates _download function in package.py to download files during buildtime.
downloads epel-release-latest-8.noarch.rpm and epel-release-latest-9.noarch.rpm to artifacts dir during build and adds it to tar file
rhel.sh installs epel-release from artifacts dir for both rhel and almalinux if not already installed