### PR TITLE
Use scalelib 1.0.8

### DIFF
--- a/azure-slurm/package.py
+++ b/azure-slurm/package.py
@@ -11,7 +11,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-SCALELIB_VERSION = "1.0.7"
+SCALELIB_VERSION = "1.0.8"
 CYCLECLOUD_API_VERSION = "8.7.1"
 
 


### PR DESCRIPTION
Pulls in 1.0.8 of scalelib to resolve installation issues under python 3.12 of the latest HPC images.