### PR TITLE
Add override options for slurmd and munge.

### DIFF
--- a/azure-slurm-install/install.py
+++ b/azure-slurm-install/install.py
@@ -765,6 +765,18 @@ def setup_slurmd(s: InstallSettings) -> None:
         group=s.slurm_grp,
         mode="0700",
     )
+
+    ilib.directory(
+        "/etc/systemd/system/slurmd.service.d", owner="root", group="root", mode=755
+    )
+
+    ilib.template(
+        "/etc/systemd/system/slurmd.service.d/override.conf",
+        source="templates/slurmd.override",
+        owner="root",
+        group="root",
+        mode=644,
+    )
     ilib.enable_service("slurmd")
 
 def setup_slurmrestd(s: InstallSettings) -> None:

--- a/azure-slurm-install/templates/munge.override
+++ b/azure-slurm-install/templates/munge.override
@@ -1,2 +1,5 @@
 [Service]
 Restart=always
+RestartSec=10s
+RuntimeDirectory=munge
+RuntimeDirectoryMode=0755

--- a/azure-slurm-install/templates/slurm.conf.template
+++ b/azure-slurm-install/templates/slurm.conf.template
@@ -45,6 +45,7 @@ ReconfigFlags=KeepPowerSaveSettings
 ResumeTimeout=1800
 SuspendTimeout=600
 SuspendTime=300
+SlurmctldTimeout=30
 ResumeProgram=/opt/azurehpc/slurm/resume_program.sh
 ResumeFailProgram=/opt/azurehpc/slurm/resume_fail_program.sh
 SuspendProgram=/opt/azurehpc/slurm/suspend_program.sh

--- a/azure-slurm-install/templates/slurmd.override
+++ b/azure-slurm-install/templates/slurmd.override
@@ -1,0 +1,14 @@
+[Unit]
+After=munge.service network-online.target local-fs.target remote-fs.target sssd.service
+Wants=network-online.target
+Requires=munge.service network-online.target remote-fs.target local-fs.target
+RequiresMountsFor=/sched
+
+[service]
+EnvironmentFile=-/etc/sysconfig/slurmd
+EnvironmentFile=-/etc/default/slurmd
+RuntimeDirectory=slurm
+RuntimeDirectoryMode=0755
+ExecStart=/usr/sbin/slurmd --systemd $SLURMD_OPTIONS
+Restart=always
+RestartSec=10s


### PR DESCRIPTION
For slurmd, this commit adds startup ordering requirements so slurmd does not start too early on reboot/restart. It needs to wait for filesystem and network to be up and /sched to be mounted.

Also add slurmctld timeout for quicker HA recovery.