### PR TITLE
make sacct metrics and prometheus queries resilient to restarts

### DIFF
--- a/azure-slurm-exporter/dashboards/azslurm.json
+++ b/azure-slurm-exporter/dashboards/azslurm.json
@@ -630,15 +630,7 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": ""
-            },
-            "properties": []
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -655,7 +647,7 @@
           "reducer": [
             "count"
           ],
-          "show": true
+          "show": false
         },
         "frameIndex": 3,
         "showHeader": true,
@@ -689,6 +681,17 @@
           "options": {}
         },
         {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Number of Allocated Nodes"
+              }
+            ]
+          }
+        },
+        {
           "id": "organize",
           "options": {
             "excludeByName": {
@@ -696,6 +699,7 @@
               "cluster": true,
               "instance": true,
               "job": true,
+              "microsoft.amwresourceid": true,
               "physical_host": true,
               "state": true,
               "subscription": true
@@ -705,17 +709,6 @@
             "renameByName": {
               "Trend #A": "Number of Allocated Nodes"
             }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Number of Allocated Nodes"
-              }
-            ]
           }
         }
       ],
@@ -776,7 +769,7 @@
                   {
                     "targetBlank": true,
                     "title": "Failed Jobs in last 6 months",
-                    "url": "/d/cff0f6w0qqwaoa/failed-jobs-dashboard?orgId=1&from=${__from}&to=${__to}&timezone=browser&${promDatasource:queryparam}&${partition:queryparam}&${cluster:queryparam}&viewPanel=panel-1052"
+                    "url": "/d/cff0f6w0qqwaoa/failed-jobs-dashboard?orgId=1&from=${__from}&to=${__to}&timezone=browser&${promDatasource:queryparam}&${partition:queryparam}&${cluster:queryparam}&viewPanel=panel-1054"
                   }
                 ]
               }
@@ -813,7 +806,7 @@
         "x": 19,
         "y": 15
       },
-      "id": 1052,
+      "id": 1055,
       "options": {
         "displayLabels": [
           "name",
@@ -850,48 +843,8 @@
             "uid": "${promDatasource}"
           },
           "editorMode": "code",
-          "expr": "floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"})[$__range:$__interval])) !=0",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "Failed Jobs",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${promDatasource}"
-          },
-          "editorMode": "code",
           "exemplar": false,
-          "expr": "floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state=\"completed\"})[$__range:$__interval])) !=0",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "Completed Jobs",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${promDatasource}"
-          },
-          "editorMode": "code",
-          "expr": "floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\"})[$__range:$__interval])) !=0",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "Finished Jobs",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${promDatasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"})[$__range:$__interval])) != 0 and sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset $__range)) or (sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"}) unless sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset $__range))",
+          "expr": "floor(increase(\r\n  sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} or vector(0))[$__range:$__interval]\r\n))",
           "hide": false,
           "instant": true,
           "legendFormat": "Failed Jobs",
@@ -905,7 +858,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state=\"completed\"})[$__range:$__interval])) != 0 and sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state=\"completed\"} offset $__range)) or (sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state=\"completed\"}) unless sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state=\"completed\"} offset $__range))",
+          "expr": "floor(increase(\r\n  sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state=\"completed\"} or vector(0))[$__range:$__interval]\r\n))",
           "hide": false,
           "instant": true,
           "legendFormat": "Completed Jobs",
@@ -919,9 +872,10 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\"})[$__range:$__interval])) != 0 and sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\"} offset $__range)) or (sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\"}) unless sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\"} offset $__range))",
+          "expr": "floor(increase(\r\n  sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\"} or vector(0))[$__range:$__interval]\r\n))",
           "hide": false,
           "instant": true,
+          "interval": "",
           "legendFormat": "Finished Jobs",
           "range": false,
           "refId": "D"
@@ -1744,6 +1698,7 @@
               "cluster": true,
               "instance": true,
               "job": true,
+              "microsoft.amwresourceid": true,
               "physical_host": true,
               "subscription": true
             },
@@ -2068,6 +2023,7 @@
               "cluster": true,
               "instance": true,
               "job": true,
+              "microsoft.amwresourceid": true,
               "physical_host": true,
               "subscription": true
             },
@@ -2123,7 +2079,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "## Disclaimer\n\n> **⚠️ Note:** Under heavy system load, dashboards may update more slowly. Displayed metrics may experience delays and should not be relied upon as a real-time source of truth during peak activity.",
+        "content": "## Disclaimer\n\n> **⚠️ Note:** Under heavy system load, dashboards may update more slowly. Displayed metrics may experience delays and should not be relied upon as a real-time source of truth during peak activity. Gaps in the dashboard may be seen when azslurm-exporter is down or when slurmctld is down.",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -2229,6 +2185,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "AzSlurm Dashboard",
-  "uid": "aff0elgh9i0hsa",
+  "uid": "dfjzrqhfl8c1sc",
   "version": 1
 }

--- a/azure-slurm-exporter/dashboards/failed-jobs.json
+++ b/azure-slurm-exporter/dashboards/failed-jobs.json
@@ -91,17 +91,17 @@
         "x": 0,
         "y": 1
       },
-      "id": 1052,
+      "id": 1054,
       "options": {
         "cellHeight": "lg",
         "footer": {
-          "countRows": false,
+          "countRows": true,
           "enablePagination": false,
           "fields": "",
           "reducer": [
-            "sum"
+            "count"
           ],
-          "show": false
+          "show": true
         },
         "frameIndex": 1,
         "showHeader": true,
@@ -116,21 +116,25 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(floor(increase(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"}[$__range])) != 0 and sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset $__range) or (sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} unless sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset $__range)",
-          "instant": true,
+          "expr": "sacct_failed_jobs{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset -5m",
+          "hide": false,
+          "instant": false,
           "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Failed Jobs by Exit Code between $__from and $__to",
+      "title": "Failed Jobs between $__from and $__to",
       "transformations": [
         {
           "id": "timeSeriesTable",
-          "options": {}
+          "options": {
+            "B": {
+              "stat": "lastNotNull"
+            }
+          }
         },
         {
-          "disabled": true,
           "id": "labelsToFields",
           "options": {
             "keepLabels": [
@@ -145,27 +149,37 @@
           "id": "organize",
           "options": {
             "excludeByName": {
+              "Trend #B": true,
               "__name__": true,
               "cluster": true,
+              "endtime": true,
               "instance": true,
               "job": true,
+              "microsoft.amwresourceid": true,
               "physical_host": true,
               "start_datetime hpc": true,
+              "starttime": true,
               "subscription": true
             },
             "includeByName": {},
             "indexByName": {
-              "Trend #A": 3,
+              "Trend #B": 16,
               "__name__": 0,
               "cluster": 1,
-              "exit_code": 5,
-              "instance": 6,
-              "job": 7,
+              "endtime": 13,
+              "exit_code": 7,
+              "instance": 8,
+              "job": 9,
+              "jobid": 3,
+              "jobname": 4,
+              "microsoft.amwresourceid": 14,
+              "nodelist": 5,
               "partition": 2,
-              "physical_host": 8,
-              "start_datetime": 9,
-              "state": 4,
-              "subscription": 10
+              "physical_host": 10,
+              "reason": 15,
+              "starttime": 12,
+              "state": 6,
+              "subscription": 11
             },
             "renameByName": {
               "Trend #A": "# of Failed Jobs"
@@ -174,76 +188,6 @@
         }
       ],
       "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${promDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "No failed Jobs within time range",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 16,
-        "x": 0,
-        "y": 12
-      },
-      "id": 1053,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.9",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${promDatasource}"
-          },
-          "editorMode": "code",
-          "expr": "(floor(increase(sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"})[$__range:$__interval])) != 0 and sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset $__range)) or (sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"}) unless sum(sacct_terminal_jobs_total{cluster=\"$cluster\",partition=~\"$partition\",state!=\"completed\"} offset $__range))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Total Failed Jobs between $__from and $__to",
-      "type": "stat"
     }
   ],
   "preload": false,

--- a/azure-slurm-exporter/exporter/sacct.py
+++ b/azure-slurm-exporter/exporter/sacct.py
@@ -1,10 +1,10 @@
 from .exporter import BaseCollector
 from collections import namedtuple
-from prometheus_client import Counter, disable_created_metrics
-from datetime import datetime, timedelta
+from prometheus_client import Counter, disable_created_metrics, Gauge
+from datetime import datetime
 import logging
 import exporter.util as util
-from typing import List
+from typing import List, Union
 log = logging.getLogger(__name__)
 
 class SacctNotAvailException(Exception):
@@ -37,7 +37,7 @@ class Sacct(BaseCollector):
             "153:0": "SIGXFSZ - File size limit",
         }
 
-    def __init__(self, binary_path="/usr/bin/sacct", interval=300, timeout=120):
+    def __init__(self, binary_path="/usr/bin/sacct", interval=300, timeout=120, starttime=None):
         self.binary_path = binary_path
         self.interval = interval
         self.timeout = timeout
@@ -46,9 +46,10 @@ class Sacct(BaseCollector):
         self.default_output_fmt = "jobid,jobname,nodelist,nnodes,partition,exitcode,derivedexitcode,state,user,start,submit,end,reason"
         self.sacct_output = namedtuple("sacct_output", self.default_output_fmt)
         self.terminal_states = "completed,failed,cancelled,timeout,node_fail,preempted,out_of_memory,deadline,boot_fail"
-        self.starttime = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        self.starttime = starttime if starttime is not None else datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
         self.endtime = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
         self.default_options = ["-P" ,"-n", "-o", self.default_output_fmt, "-s", self.terminal_states, "--allocations" ]
+        self.cached_output={"sacct_metrics":[]}
 
     def initialize(self) -> None:
         """
@@ -67,17 +68,20 @@ class Sacct(BaseCollector):
         """
         self.launch_task(func=self.sacct_query, interval=self.interval)
 
-    def export_metrics(self) -> List[Counter]:
+    def export_metrics(self) -> List[Union[Counter,Gauge]]:
         """
         Return the most recently collected sacct metrics for Prometheus to scrape.
         """
-        return [self.sacct_terminal_jobs]
+        return self.cached_output["sacct_metrics"]
 
-    def parse_output(self, stdout) -> None:
+    def parse_output(self, stdout) -> List[Union[Counter,Gauge]]:
         """
         Parse sacct command output and increment terminal jobs metric for each job in the output to describe total number of finished jobs by partition,
-        exit_code, reason, and state.
+        exit_code, reason, and state as well as return failed jobs gauge describing each job that failed within the time interval of the query.
         """
+        sacct_failed_jobs = Gauge("sacct_failed_jobs","Number of failed slurm jobs in an interval",
+                                    ["jobid","jobname","nodelist","partition", "exit_code","reason","state", "starttime","endtime"], registry=None)
+
         lines = stdout.decode().strip().splitlines()
         log.debug(f"Number of jobs:{len(lines)}")
         lines_iter = (line.split("|") for line in lines)
@@ -88,6 +92,21 @@ class Sacct(BaseCollector):
                 exit_code=row.exitcode,
                 reason=reason,
                 state=row.state.lower()).inc()
+
+            if row.state.lower() != "completed":
+                sacct_failed_jobs.labels(
+                    jobid=row.jobid,
+                    jobname=row.jobname,
+                    nodelist=row.nodelist,
+                    partition=row.partition,
+                    exit_code=row.exitcode,
+                    reason=reason,
+                    state=row.state.lower(),
+                    starttime=self.starttime,
+                    endtime=self.endtime).set(1)
+
+
+        return [self.sacct_terminal_jobs, sacct_failed_jobs]
 
     async def sacct_query(self) -> None:
         """
@@ -105,7 +124,7 @@ class Sacct(BaseCollector):
         log.debug(f"running sacct query between {self.starttime} and {self.endtime}")
         try:
             proc = await self.run_command(*args, timeout=self.timeout)
-            self.parse_output(proc.stdout)
+            self.cached_output["sacct_metrics"] = self.parse_output(proc.stdout)
         except Exception as e:
             log.error(e)
             return

--- a/azure-slurm-exporter/test/test_sacct.py
+++ b/azure-slurm-exporter/test/test_sacct.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 from exporter.sacct import Sacct, SacctNotAvailException
 from exporter.exporter import CommandFailedException, CommandTimedOutException
-from prometheus_client import Counter
+from prometheus_client import Counter, Gauge
 
 
 class TestSacctInitialize:
@@ -39,10 +39,10 @@ class TestSacctParseOutput:
     def test_parse_output_single_completed_job(self, sacct):
         """Test parse_output handles a single completed job."""
         stdout = b"1001|myjob|node1|1|batch|0:0|0:0|COMPLETED|user1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         samples_by_keys = {}
         metrics = sacct.export_metrics()
-        assert len(metrics) == 1
+        assert len(metrics) == 2
 
         for metric in metrics:
             for family in metric.collect():
@@ -60,7 +60,7 @@ class TestSacctParseOutput:
             b"1001|job1|node1|1|batch|0:0|0:0|COMPLETED|user1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
             b"1002|job2|node2|1|batch|137:0|0:0|FAILED|user2|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
         )
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         all_samples = []
@@ -74,9 +74,8 @@ class TestSacctParseOutput:
 
     def test_parse_output_empty_output(self, sacct):
         """Test parse_output handles empty output."""
-        sacct.parse_output(b"")
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(b"")
         metrics = sacct.export_metrics()
-
         # Counter should have no samples when no jobs parsed
         for metric in metrics:
             for family in metric.collect():
@@ -90,7 +89,7 @@ class TestSacctParseOutput:
             b"2|job2|node2|1|gpu|0:0|0:0|COMPLETED|u2|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
             b"3|job3|node3|1|cpu|1:0|0:0|FAILED|u3|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
         )
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         terminal_metric = None
@@ -120,15 +119,17 @@ class TestSacctExportMetrics:
         return sacct
 
     def test_export_metrics_returns_counter(self, sacct):
-        """Test export_metrics returns a Counter instance."""
+        """Test export_metrics returns a Counter and Gauge instance."""
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(b"")
         metrics = sacct.export_metrics()
-        assert len(metrics) == 1
+        assert len(metrics) == 2
         assert isinstance(metrics[0], Counter)
+        assert isinstance(metrics[1], Gauge)
 
     def test_export_metrics_same_reference(self, sacct):
         """Test export_metrics returns consistent references."""
         stdout = b"1001|job1|node1|1|batch|0:0|0:0|COMPLETED|user1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
 
         metrics1 = sacct.export_metrics()
         metrics2 = sacct.export_metrics()
@@ -156,7 +157,7 @@ class TestSacctExitCodeMapping:
     def test_exit_code_mapped_to_reason_label(self, sacct):
         """Test exit code is mapped to the reason label in metrics."""
         stdout = b"1001|job1|node1|1|batch|137:0|0:0|FAILED|user1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         for metric in metrics:
@@ -168,7 +169,7 @@ class TestSacctExitCodeMapping:
     def test_unknown_exit_code_defaults_to_empty(self, sacct):
         """Test unknown exit code defaults to empty reason."""
         stdout = b"1001|job1|node1|1|batch|99:0|0:0|FAILED|user1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         for metric in metrics:
@@ -196,7 +197,7 @@ class TestSacctMetricValues:
             b"2|job2|node1|1|batch|0:0|0:0|COMPLETED|u2|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
             b"3|job3|node1|1|batch|0:0|0:0|COMPLETED|u3|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
         )
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         for metric in metrics:
@@ -210,8 +211,8 @@ class TestSacctMetricValues:
         batch1 = b"1|job1|node1|1|batch|0:0|0:0|COMPLETED|u1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
         batch2 = b"2|job2|node1|1|batch|0:0|0:0|COMPLETED|u2|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
 
-        sacct.parse_output(batch1)
-        sacct.parse_output(batch2)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(batch1)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(batch2)
         metrics = sacct.export_metrics()
 
         for metric in metrics:
@@ -223,7 +224,7 @@ class TestSacctMetricValues:
     def test_all_values_non_negative(self, sacct):
         """Test all metric values are non-negative."""
         stdout = b"1|job1|node1|1|batch|0:0|0:0|COMPLETED|u1|2024-01-01T10:00:00|2024-01-01T09:00:00|2024-01-01T11:00:00|None\n"
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         for metric in metrics:
@@ -243,7 +244,7 @@ class TestSacctMetricValues:
                 % (i, i, exit_code, state)
             )
         stdout = b"".join(lines)
-        sacct.parse_output(stdout)
+        sacct.cached_output["sacct_metrics"] = sacct.parse_output(stdout)
         metrics = sacct.export_metrics()
 
         terminal_metric = None


### PR DESCRIPTION
- Make starttime datetime.now() during sacct init so first collect cycle doesnt include any previous jobs if exporter restarts
- Add sacct_failed_jobs Gauge to track failed jobs within a period of time
- Adjust dashboard queries to account for restarts