### PR TITLE
set pipefail to exit start-services.sh correctly

### DIFF
--- a/azure-slurm-install/start-services.sh
+++ b/azure-slurm-install/start-services.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -o pipefail
 
 run_slurmdbd_via_systemctl() {
 
@@ -268,4 +269,6 @@ ensure_enroot_dir() {
         run_azslurm_exporter
     fi
 
+    echo "Successfully started all relevant slurm services"
+    
 } 2>&1 | tee -a /var/log/azure-slurm-install.log


### PR DESCRIPTION
Bug fix: start-services.sh wasnt exiting correctly and jetpack was incorrectly setting node as converge suceeded. Added set -o pipefail to make sure we return the right exit code 