### PR TITLE
fix: return helpful exception when available count is 0 for a slurm partition with idle~ nodes

### DIFF
--- a/azure-slurm/slurmcc/allocation.py
+++ b/azure-slurm/slurmcc/allocation.py
@@ -69,7 +69,12 @@ def resume(
             constraints, node_count=1, allow_existing=False
         )
         if len(result.nodes) != 1:
-            raise RuntimeError()
+            reasons = "; ".join(result.reasons) if getattr(result, "reasons", None) else "no reason reported by node manager"
+            raise AzureSlurmError(
+                f"Failed to allocate node {name} in bucket {bucket.bucket_id} "
+                f"(partition={partition.name}): expected 1 node, got {len(result.nodes)}. "
+                f"Reasons: {reasons}"
+            )
         result.nodes[0].name_format = name
         nodes.extend(result.nodes)
 


### PR DESCRIPTION
azslurm throws an exception when available count is 0 for a slurm partition with idle~ nodes with no error message
```[root@rc-rocky8-scheduler cc-admin]# azslurm resume --node-list rc-rocky8-htc-5
Error '': See the rest in the log file
```

These changes includes reasons why allocation failed:

```

[root@rc-rocky8-scheduler logs]# azslurm resume --node-list rc-rocky8-htc-5
Error 'Failed to allocate node rc-rocky8-htc-5 in bucket 50fb069a-f229-47c5-b531-de8f96e80963 (partition=htc): expected 1 node, got 0. Reasons: Could not allocate based on the selection criteria: [NodePropertyConstraint(Node.exists == False), {'node.bucket_id': '50fb069a-f229-47c5-b531-de8f96e80963', 'exclusive': True}] all_or_nothing=False allow_existing=False; Bucket NodeBucket(htc, available=0, size=Standard_F2s_v2, id=50fb069a-f229-47c5-b531-de8f96e80963) does not have capacity: Required=1 Available=0': See the rest in the log file

```
