### PR TITLE
Add slurm.primary_scheduler_name to match secondary_scheduler_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Slurm is a highly configurable open source workload manager. See the [Slurm proj
     9. [Topology](#topology)
     10. [GB200/GB300 IMEX Support](#gb200gb300-imex-support)
     11. [Setting KeepAlive in CycleCloud](#setting-keepalive)
-    12. [Slurmrestd](#slurmrestd)
-    13. [Node Health Checks](#node-health-checks)
-    14. [Monitoring](#monitoring)
+    12. [Custom Scheduler Names With High-Availability](#custom-scheduler-names-with-high-availability)
+    13. [Slurmrestd](#slurmrestd)
+    14. [Node Health Checks](#node-health-checks)
+    15. [Monitoring](#monitoring)
         1. [AzSlurm Exporter](#azslurm-exporter)
             1. [Exported Metrics](#exported-metrics)
             2. [Configure Exporter Port](#configure-exporter-port)
@@ -377,6 +378,17 @@ Cyclecloud Slurm clusters now include prolog and epilog scripts to enable and cl
 Added in 4.0.5: If the KeepAlive attribute is set in the CycleCloud UI, then the azslurmd will add that node's name to the `SuspendExcNodes` attribute via scontrol. Note that it is required that `ReconfigFlags=KeepPowerSaveSettings` is set in the slurm.conf, as is the default as of 4.0.5. Once KeepALive is set back to false, `azslurmd` will then remove this node from `SuspendExcNodes`.
 
 If a node is added to `SuspendExcNodes` either via `azslurm keep_alive` or via the scontrol command, then `azslurmd` will not remove this node from the `SuspendExcNodes` if KeepAlive is false in CycleCloud. However, if the node is later set to KeepAlive as true in the UI then `azslurmd` will then remove it from `SuspendExcNodes` when the node is set back to KeepAlive is false.
+
+### Custom Scheduler Names With High-Availability
+To override the default scheduler and scheduler-ha node names, i.e. such that you have a custom template which redefines [node scheduler] or [nodearray scheduler-ha], set the following values under the cluster or nodearray `configuration` section in your template:
+
+```ini
+[[[configuration]]]
+slurm.primary_scheduler_name = <scheduler-node-name>
+slurm.secondary_scheduler_name = <scheduler-ha-node-name>
+```
+
+These settings are required to tell the installer which exact CycleCloud node represents the primary and secondary scheduler. **The [node]'s hostname is controlled by the ComputerName attribute, which will still be ClusterName-scheduler unless you change this. Only the [nodearray] here will automatically match the hostname.** 
 
 ### Slurmrestd
 As of version 4.0.5, `slurmrestd` is automatically configured and started on the scheduler node and scheduler-ha node for all Slurm clusters. This REST API service provides programmatic access to Slurm functionality, allowing external applications and tools to interact with the cluster. For more information on the Slurm REST API, see the [official Slurm REST API documentation](https://slurm.schedmd.com/rest_api.html). Slurmrestd is configured with JWT authentication if the libjwt library is installed, otherwise it uses munge-only authentication. For more information on authentication refer to the [Security section](https://slurm.schedmd.com/rest.html#security) of the Slurm REST API documentation.

--- a/azure-slurm-install/install.py
+++ b/azure-slurm-install/install.py
@@ -133,6 +133,7 @@ class InstallSettings:
         )
         self.launch_parameters = config["slurm"].get("launch_parameters", "")
 
+        self.primary_scheduler_name = config["slurm"].get("primary_scheduler_name") or "scheduler"
         self.secondary_scheduler_name = config["slurm"].get("secondary_scheduler_name")
         self.is_primary_scheduler = config["slurm"].get("is_primary_scheduler", self.mode == "scheduler")
         self.config_dir = f"/sched/{self.slurm_cluster_name}"
@@ -1164,7 +1165,7 @@ def main() -> None:
         if settings.is_primary_scheduler == False:
             # This is the HA node.
             logging.info(f"Secondary Scheduler {settings.secondary_scheduler_name} starting wait on primary to finish converging.")
-            ilib.await_node_converge(settings.config, "scheduler", timeout=600)
+            ilib.await_node_converge(settings.config, settings.primary_scheduler_name, timeout=600)
 
     if settings.mode == "execute":
         setup_slurmd(settings)


### PR DESCRIPTION
If a user has a custom name for the scheduler node, then there is no configuration to tell the installib what the primary scheduler node name is, like we do for the secondary scheduler node.