### PR TITLE
Make our install directory with explicit permissions.

### DIFF
--- a/azure-slurm/install.sh
+++ b/azure-slurm/install.sh
@@ -21,8 +21,22 @@ find_python3() {
 }
 
 setup_venv() {
-    
+
     set -e
+
+    # Override any restrictive umask (e.g. UMASK 027 on CIS-hardened images)
+    # for the duration of this function so that all directories and files
+    # created here — including the venv, pip-installed packages, and generated
+    # wrapper scripts — get predictable 0755/0644 permissions.
+    local old_umask
+    old_umask=$(umask)
+    umask 022
+
+    # Create parent directories with explicit 0755 permissions before the venv.
+    # Also chmod explicitly in case the directories already exist with restrictive
+    # permissions from a previous (failed) run.
+    install -d -m 0755 /opt/azurehpc && chmod 0755 /opt/azurehpc
+    install -d -m 0755 $INSTALL_DIR && chmod 0755 $INSTALL_DIR
 
     $PYTHON_PATH -c "import sys; sys.exit(0)" || (echo "$PYTHON_PATH is not a valid python3 executable. Please install python3.11 or higher." && exit 1)
     $PYTHON_PATH -m pip --version > /dev/null || $PYTHON_PATH -m ensurepip
@@ -31,6 +45,11 @@ setup_venv() {
     set +e
     source $VENV/bin/activate
     set -e
+
+    # Set the RETURN trap only after 'source' to avoid it firing prematurely
+    # when the sourced script returns. This ensures the original umask is
+    # restored on any subsequent exit path — both normal return and early error.
+    trap "umask $old_umask" RETURN
 
     # ensure wheel is installed
     python3 -m pip install wheel
@@ -86,11 +105,11 @@ fi
 EOF
     fi
 
-    azslurm -h 2>&1 > /dev/null || exit 1
+    azslurm -h > /dev/null 2>&1 || return 1
 }
 
 setup_install_dir() {
-    mkdir -p $INSTALL_DIR/logs
+    install -d -m 0755 $INSTALL_DIR/logs && chmod 0755 $INSTALL_DIR/logs
     cp logging.conf $INSTALL_DIR/
     cp sbin/*.sh $INSTALL_DIR/
     chown slurm:slurm $INSTALL_DIR/*.sh


### PR DESCRIPTION
In hardened umask environments the directories are created with restrictive permissions preventing slurm user from running prolog.

https://github.com/Azure/cyclecloud-slurm/issues/519