### PR TITLE
Don't add recurisve permissions for /run/munge dir.

### DIFF
--- a/azure-slurm-install/install.py
+++ b/azure-slurm-install/install.py
@@ -307,7 +307,7 @@ def fix_permissions(s: InstallSettings) -> None:
     )
 
     ilib.directory(
-        "/run/munge", owner=s.munge_user, group=s.munge_grp, mode=755, recursive=True
+        "/run/munge", owner=s.munge_user, group=s.munge_grp, mode=755
     )
 
     ilib.directory(f"{s.config_dir}/munge", owner=s.munge_user, group=s.munge_grp, mode=700)


### PR DESCRIPTION
/run/munge dir contains the munge socket and munge permissions for the socket need to be 777 so slurm/other users can talk to it.

When we run install.py-- this change puts existing running munge service in a bad state.