### PR TITLE
Resctrict autoscale.json file permissions 

### DIFF
--- a/azure-slurm/sbin/init-config.sh
+++ b/azure-slurm/sbin/init-config.sh
@@ -67,12 +67,24 @@ fi
 escaped_cluster_name=$(python3 -c "import re; print(re.sub('[^a-zA-Z0-9-]', '-', '$CLUSTER_NAME').lower())")
 
 config_dir=/sched/$escaped_cluster_name
-azslurm initconfig --username $USERNAME \
-                --password $PASSWORD \
-                --url      $URL \
-                --cluster-name $CLUSTER_NAME\
-                --config-dir $config_dir \
-                --accounting-subscription-id $ACCOUNTING_SUBSCRIPTION_ID \
+tmp_autoscale_json=$(mktemp "$INSTALL_DIR/.autoscale.json.XXXXXX")
+cleanup() {
+    rm -f "$tmp_autoscale_json"
+}
+trap cleanup EXIT
+
+# Ensure the generated credential file is never world-readable while being created.
+orig_umask=$(umask)
+umask 077
+azslurm initconfig --username "$USERNAME" \
+                --password "$PASSWORD" \
+                --url "$URL" \
+                --cluster-name "$CLUSTER_NAME" \
+                --config-dir "$config_dir" \
+                --accounting-subscription-id "$ACCOUNTING_SUBSCRIPTION_ID" \
                 --default-resource '{"select": {}, "name": "slurm_gpus", "value": "node.gpu_count"}' \
-                --cost-cache-root $INSTALL_DIR/.cache \
-                > $INSTALL_DIR/autoscale.json
+                --cost-cache-root "$INSTALL_DIR/.cache" \
+                > "$tmp_autoscale_json"
+umask "$orig_umask"
+
+install -m 600 "$tmp_autoscale_json" "$INSTALL_DIR/autoscale.json"

--- a/azure-slurm/sbin/init-config.sh
+++ b/azure-slurm/sbin/init-config.sh
@@ -74,8 +74,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Ensure the generated credential file is never world-readable while being created.
-orig_umask=$(umask)
-umask 077
+( umask 077
 azslurm initconfig --username "$USERNAME" \
                 --password "$PASSWORD" \
                 --url "$URL" \
@@ -84,7 +83,6 @@ azslurm initconfig --username "$USERNAME" \
                 --accounting-subscription-id "$ACCOUNTING_SUBSCRIPTION_ID" \
                 --default-resource '{"select": {}, "name": "slurm_gpus", "value": "node.gpu_count"}' \
                 --cost-cache-root "$INSTALL_DIR/.cache" \
-                > "$tmp_autoscale_json"
-umask "$orig_umask"
+                > "$tmp_autoscale_json" )
 
 install -m 600 "$tmp_autoscale_json" "$INSTALL_DIR/autoscale.json"

--- a/azure-slurm/sbin/init-config.sh
+++ b/azure-slurm/sbin/init-config.sh
@@ -85,4 +85,4 @@ azslurm initconfig --username "$USERNAME" \
                 --cost-cache-root "$INSTALL_DIR/.cache" \
                 > "$tmp_autoscale_json" )
 
-install -m 600 "$tmp_autoscale_json" "$INSTALL_DIR/autoscale.json"
+install -o root -g root -m 600 "$tmp_autoscale_json" "$INSTALL_DIR/autoscale.json"


### PR DESCRIPTION
Problem:
The autoscale.json file containing CycleCloud credentials (username, password, URL) is written with world-readable permissions (0644) by default, allowing any local non-root user to read and impersonate the Slurm scheduler to CycleCloud. 
https://portal.microsofticm.com/imp/v5/incidents/details/31000000645885/msrc

Solution:
Write credentials to a secure temporary file with umask 077 (owner-only)
Use install -m 600 to atomically publish the final file as read/write only by root
Add cleanup trap to ensure temp files are always removed
