### PR TITLE
fix: install autoscale.json as slurm user so slurm can autoscale

### DIFF
--- a/azure-slurm/sbin/init-config.sh
+++ b/azure-slurm/sbin/init-config.sh
@@ -85,4 +85,4 @@ azslurm initconfig --username "$USERNAME" \
                 --cost-cache-root "$INSTALL_DIR/.cache" \
                 > "$tmp_autoscale_json" )
 
-install -o root -g root -m 600 "$tmp_autoscale_json" "$INSTALL_DIR/autoscale.json"
+install -o slurm -g slurm -m 600 "$tmp_autoscale_json" "$INSTALL_DIR/autoscale.json"


### PR DESCRIPTION
fix bug where restricting permissions on autoscale.json to root caused slurm resume_program.sh to error. 

```
[slurm@testcustom-alma8-x86-custom-456c-scheduler ~]$ /opt/azurehpc/slurm/venv/bin/azslurm resume --node-list TestCustom-Alma8-x86-custom-456
c-hpc-3
ERROR:root:Unexpected error. See  for more information.
Traceback (most recent call last):
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/util.py", line 265, in _load_config
    with open(config) as fr:
         ^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/opt/azurehpc/slurm/autoscale.json'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/slurmcc/cli.py", line 1077, in main
    clilibmain(argv or sys.argv[1:], "slurm", SlurmCLI())
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/clilib.py", line 1932, in main
    args.config = load_config(args.config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/util.py", line 248, in load_config
    child = _load_config(config, [])
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/util.py", line 294, in _load_config
    raise ConfigurationException(msg)
hpc.autoscale.util.ConfigurationException: Could not parse config /opt/azurehpc/slurm/autoscale.json: [Errno 13] Permission denied: '/opt/azurehpc/slurm/autoscale.json'
Traceback (most recent call last):
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/util.py", line 265, in _load_config
    with open(config) as fr:
         ^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/opt/azurehpc/slurm/autoscale.json'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/azurehpc/slurm/venv/bin/azslurm", line 11, in <module>
    main()
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/slurmcc/cli.py", line 1077, in main
    clilibmain(argv or sys.argv[1:], "slurm", SlurmCLI())
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/clilib.py", line 1932, in main
    args.config = load_config(args.config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/util.py", line 248, in load_config
    child = _load_config(config, [])
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/azurehpc/slurm/venv/lib64/python3.11/site-packages/hpc/autoscale/util.py", line 294, in _load_config
    raise ConfigurationException(msg)
hpc.autoscale.util.ConfigurationException: Could not parse config /opt/azurehpc/slurm/autoscale.json: [Errno 13] Permission denied: '/opt/azurehpc/slurm/autoscale.json'
```