### PR TITLE
Fix slurmrestd capabilities and listen address

### DIFF
--- a/azure-slurm-install/templates/slurmrestd.override
+++ b/azure-slurm-install/templates/slurmrestd.override
@@ -1,4 +1,6 @@
 [Service]
-AmbientCapabilities=CAP_SETGID
-CapabilityBoundingSet=CAP_SETGID
+AmbientCapabilities=CAP_SETUID CAP_SETGID
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID
+ExecStart=
+ExecStart=/usr/sbin/slurmrestd $SLURMRESTD_OPTIONS $SLURMRESTD_LISTEN
 {jwt_env}


### PR DESCRIPTION
## Problem

`slurmrestd.service` fails on a default CCWS scheduler for two independent reasons:

1. The generated service configuration asks `slurmrestd` to drop privileges with both `-u slurmrestd` and `-g slurmrestd`, but the systemd capability bounding set grants only `CAP_SETGID`. The `setuid()` call therefore fails with `Operation not permitted`.
2. After granting `CAP_SETUID`, the base unit still starts with `unix:/usr/com/slurmrestd.socket`. The installer creates `/var/spool/slurmrestd/` and writes the intended endpoints to `SLURMRESTD_LISTEN`, so the hardcoded socket path does not exist.

## Change

- Grant both `CAP_SETUID` and `CAP_SETGID`.
- Clear the base unit’s `ExecStart` in the drop-in.
- Start `slurmrestd` with the generated `$SLURMRESTD_OPTIONS` and `$SLURMRESTD_LISTEN` values.

## Validation

Applied the resulting drop-in to a CCWS scheduler where the service reproduced both failures. After `systemctl daemon-reload` and restart, `slurmrestd.service` remained active and listened on both `:6820` and `/var/spool/slurmrestd/slurmrestd.socket`.